### PR TITLE
Install mock during test environment setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,7 @@
 envlist = py27,py35
 
 [testenv]
-deps=pytest
+deps=
+    pytest
+    mock==1.0.1;python_version<="2.7"
 commands=py.test


### PR DESCRIPTION
This will only install mock for python<=2.7