### PR TITLE
create ident_hash functions and associated indexes

### DIFF
--- a/cnxdb/archive-sql/schema/functions.sql
+++ b/cnxdb/archive-sql/schema/functions.sql
@@ -168,3 +168,16 @@ SELECT bool_or(is_collated)
         ON module_ident = documentid
     WHERE uuid = col_uuid AND module_version(major_version, minor_version) = col_ver
 $function$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION ident_hash(uuid uuid, major integer, minor integer)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$ select uuid || '@' || concat_ws('.', major, minor) $function$;
+
+CREATE OR REPLACE FUNCTION short_ident_hash(uuid uuid, major integer, minor integer)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$ select short_id(uuid) || '@' || concat_ws('.', major, minor) $function$;
+

--- a/cnxdb/archive-sql/schema/indexes.sql
+++ b/cnxdb/archive-sql/schema/indexes.sql
@@ -6,6 +6,8 @@ CREATE INDEX modules_uuid_idx on modules (uuid);
 CREATE INDEX modules_uuid_txt_version_idx on
     modules (CAST(uuid as text), module_version(major_version, minor_version));
 CREATE INDEX modules_short_id_idx on modules (short_id(uuid));
+CREATE INDEX modules_ident_hash on modules(ident_hash(uuid, major_version, minor_version));
+CREATE INDEX modules_short_ident_hash on modules(short_ident_hash(uuid, major_version, minor_version));
 
 CREATE INDEX latest_modules_upmodid_idx ON latest_modules  (upper(moduleid));
 CREATE INDEX latest_modules_upname_idx ON latest_modules  (upper(name));

--- a/cnxdb/publishing-sql/schema-indexes.sql
+++ b/cnxdb/publishing-sql/schema-indexes.sql
@@ -7,3 +7,4 @@
 
 
 CREATE INDEX "pending_resources_hash_idx" on "pending_resources" ("hash");
+CREATE INDEX "pending_documents_ident_hash" on pending_documents (ident_hash(uuid, major_version, minor_version));


### PR DESCRIPTION
These are needed to address some performance issues with fetching individual document metadata.