### PR TITLE
Provide a common interface for development and release tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,7 @@ __pycache__
 .DS_Store
 /*.log
 .cache
-
-# Virtualenv #
-##############
-bin
-lib
-include
+.state
 
 # Build file #
 ##############

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ python:
 addons:
   postgresql: "9.4"
 before_install:
-  - pip install pycodestyle
-  - pycodestyle --exclude=tests,migrations *.py cnxdb
-  - pycodestyle --max-line-length=200 cnxdb/tests cnxdb/migrations
+  - make lint
 
   - sudo apt-get update
   # remove zope.interface installed from aptitude
@@ -24,7 +22,7 @@ before_install:
   # - cd rhaptos.cnxmlutils && python setup.py install && cd ..
 
   # Install the coverage utility and codecov reporting utility
-  - pip install pytest pytest-cov
+  - pip install -r requirements/tests.txt
   - pip install codecov
 install:
   - pip install .
@@ -39,7 +37,7 @@ before_script:
   - cd ..
 script:
   # This is the same as `python setup.py test` with a coverage wrapper.
-  - py.test --cov-config .coveragerc --cov=cnxdb
+  - py.test
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,144 @@
+STATEDIR = $(PWD)/.state
+BINDIR = $(STATEDIR)/env/bin
+
+# Short descriptions for commands (var format _SHORT_DESC_<cmd>)
+_SHORT_DESC_DOCS := "Build docs"
+_SHORT_DESC_LINT := "Run linting tools on the codebase"
+_SHORT_DESC_PYENV := "Set up the python environment"
+_SHORT_DESC_TESTS := "Run the tests"
+
+default : help
+	@echo "You must specify a command"
+	@exit 1
+
+# ###
+#  Helpers
+# ###
+
+_REQUIREMENTS_FILES = requirements/main.txt requirements/docs.txt requirements/tests.txt requirements/lint.txt
+VENV_EXTRA_ARGS =
+
+$(STATEDIR)/env/pyvenv.cfg : $(_REQUIREMENTS_FILES)
+ifeq ($(PYTHON_VERSION),2)
+	@echo "Using Python 2..."
+	rm -rf $(STATEDIR)/env
+	virtualenv $(VENV_EXTRA_ARGS) $(STATEDIR)/env
+	# Mark this as having been built
+	touch $(STATEDIR)/env/pyvenv.cfg
+else
+	@echo "Using Python 3..."
+	# Create our Python 3 virtual environment
+	rm -rf $(STATEDIR)/env
+	python3 -m venv $(VENV_EXTRA_ARGS) $(STATEDIR)/env
+endif
+	# Upgrade tooling requirements
+	$(BINDIR)/python -m pip install --upgrade pip setuptools wheel
+
+	# Install requirements
+	$(BINDIR)/python -m pip install $(foreach req,$(_REQUIREMENTS_FILES),-r $(req))
+	# Install the package
+	$(BINDIR)/python -m pip install -e .
+
+# /Helpers
+
+# ###
+#  Help
+# ###
+
+help :
+	@echo ""
+	@echo "Usage: make <cmd> [<VAR>=<val>, ...]"
+	@echo ""
+	@echo "Where <cmd> can be:"  # alphbetical please
+	@echo "  * docs -- ${_SHORT_DESC_DOCS}"
+	@echo "  * help -- this info"
+	@echo "  * help-<cmd> -- for more info"
+	@echo "  * lint -- ${_SHORT_DESC_LINT}"
+	@echo "  * pyenv -- ${_SHORT_DESC_PYENV}"
+	@echo "  * tests -- ${_SHORT_DESC_TESTS}"
+	@echo "  * version -- Print the version"
+	@echo ""
+	@echo "Where <VAR> can be:"  # alphbetical please
+	@echo ""
+
+# /Help
+
+# ###
+#  Pyenv
+# ###
+
+# Specify the major python version: 2 or 3 (default)
+PYTHON_VERSION = 3
+
+help-pyenv :
+	@echo "${_SHORT_DESC_PYENV}"
+	@echo "Usage: make pyenv"
+	@echo ""
+	@echo "Where <VAR> could be:"  # alphbetical please
+	@echo "  * PYTHON_VERSION -- major version of python to use: 2 or 3 (default: '$(PYTHON_VERSION)')"
+	@echo "  * VENV_EXTRA_ARGS -- extra arguments to give venv (default: '$(VENV_EXTRA_ARGS)')"
+
+pyenv : $(STATEDIR)/env/pyvenv.cfg
+
+# /Pyenv
+
+# ###
+#  Tests
+# ###
+
+TESTS =
+TESTS_EXTRA_ARGS =
+
+help-tests :
+	@echo "${_SHORT_DESC_TESTS}"
+	@echo "Usage: make tests [<VAR>=<val>, ...]"
+	@echo ""
+	@echo "Where <VAR> could be:"  # alphbetical please
+	@echo "  * TESTS -- specify the test to run (default: '$(TESTS)')"
+	@echo "  * TESTS_EXTRA_ARGS -- extra arguments to give ~tox~ (default: '$(TESTS_EXTRA_ARGS)')"
+	@echo "    (see also setup.cfg's pytest configuration)"
+
+tests : $(STATEDIR)/env/pyvenv.cfg
+	tox $(TESTS_EXTRA_ARGS) $(TESTS)
+
+# /Tests
+
+# ###
+#  Version
+# ###
+
+version help-version : .git
+	@$(BINDIR)/python setup.py --version 2> /dev/null
+
+# /Version
+
+# ###
+#  Docs
+# ###
+
+help-docs :
+	@echo "${_SHORT_DESC_DOCS}"
+	@echo "Usage: make docs"
+
+docs : $(STATEDIR)/env/pyvenv.cfg
+	$(MAKE) -C docs/ doctest SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"
+	$(MAKE) -C docs/ html SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"
+
+# /Docs
+
+# ###
+#  Lint
+# ###
+
+help-lint :
+	@echo "${_SHORT_DESC_LINT}"
+	@echo "Usage: make lint"
+
+lint : $(STATEDIR)/env/pyvenv.cfg setup.cfg
+	$(BINDIR)/python -m flake8 .
+	@echo '====  ====  ====  ====  ====  ====  ====  ====  ====  ===='
+	$(BINDIR)/python -m doc8.main README.rst docs/
+
+# /Lint
+
+.PHONY: docs

--- a/cnxdb/init/__init__.py
+++ b/cnxdb/init/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-from .exceptions import *
-from .main import *
+from .exceptions import *  # noqa: F401,F403
+from .main import *  # noqa: F401,F403

--- a/cnxdb/init/main.py
+++ b/cnxdb/init/main.py
@@ -113,7 +113,8 @@ def init_venv(connection_string):
                            "FROM information_schema.schemata "
                            "WHERE schema_name = 'venv';")
             try:
-                schema_exists = cursor.fetchone()[0]
+                # Does the schema already exist?
+                cursor.fetchone()[0]
             except TypeError:
                 cursor.execute("CREATE SCHEMA venv")
                 try:

--- a/cnxdb/tests/cli/test_main.py
+++ b/cnxdb/tests/cli/test_main.py
@@ -74,7 +74,7 @@ def test_init_without_dbname(connection_string_parts):
     args.extend(_translate_parts_to_args(connection_string_parts)[6:])
 
     with pytest.raises(SystemExit) as exc_info:
-        return_code = main(args)
+        main(args)
     assert exc_info.value.code == 2
 
 
@@ -84,7 +84,7 @@ def test_init_without_user(connection_string_parts):
     args = ['init'] + _translate_parts_to_args(connection_string_parts)[:6]
 
     with pytest.raises(SystemExit) as exc_info:
-        return_code = main(args)
+        main(args)
     assert exc_info.value.code == 2
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,10 +1,6 @@
 API
 ===
 
-Utilities
-=========
-
-.. automodule:: cnxdb.utils
 
 Initialization
 ==============
@@ -14,33 +10,11 @@ Initialization
 
 .. automodule:: cnxdb.init
 
-:mod:`cnxdb.manifest`
----------------------
+:mod:`cnxdb.init.manifest`
+--------------------------
 
-.. automodule:: cnxdb.manifest
+.. automodule:: cnxdb.init.manifest
 
-CRUD
-====
-
-:mod:`cnxdb.create`
--------------------
-
-.. automodule:: cnxdb.create
-
-:mod:`cnxdb.delete`
--------------------
-
-.. automodule:: cnxdb.delete
-   
-:mod:`cnxdb.read`
------------------
-
-.. automodule:: cnxdb.read
-
-:mod:`cnxdb.update`
--------------------
-
-.. automodule:: cnxdb.update
 
 Migrations
 ==========
@@ -48,4 +22,4 @@ Migrations
 :mod:`cnxdb.migrations`
 -----------------------
 
-.. automodule:: cnxdb.
+.. automodule:: cnxdb.migrations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,14 +6,6 @@
 Connexions Database Library
 ===========================
 
-.. image:: https://travis-ci.org/Connexions/cnx-db.svg
-   :target: https://travis-ci.org/Connexions/cnx-db
-
-.. image:: https://coveralls.io/repos/Connexions/cnx-db/badge.png?branch=master
-   :target: https://coveralls.io/r/Connexions/cnx-db?branch=master
-
-.. image:: https://badge.fury.io/py/cnx-db.svg
-   :target: http://badge.fury.io/py/cnx-db
 
 Contents:
 
@@ -22,18 +14,22 @@ Contents:
 
    usage
    api
+   changes
 
 
 Installation
 ------------
 
-Install using one of the following methods (run within the project root)::
+Install using::
 
-    python setup.py install
+    pip install cnx-db
 
-Or::
+Development
+-----------
 
-    pip install .
+For all things development, use the Makefile::
+
+    make help
 
 Usage
 -----
@@ -59,24 +55,19 @@ be created using the following commands::
 
 The tests can then be run using::
 
-    python setup.py test
+    make tests
 
 Or::
 
-    pip install pytest  # only run once to install dependency
+    pip install -r requirements/tests.txt
     py.test
-
-Or, to run multiple versions of python::
-
-    pip install tox  # only run once to install dependency
-    tox
 
 License
 -------
 
 This software is subject to the provisions of the GNU Affero General
 Public License Version 3.0 (AGPL). See license.txt for details.
-Copyright (c) 2016 Rice University
+Copyright (c) 2017 Rice University
 
 
 Indices and tables

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,3 @@
+# The project's documentation dependencies...
+-r ./tests.txt
+Sphinx

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,0 +1,3 @@
+# The project's lint dependencies...
+doc8
+flake8

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,0 +1,3 @@
+# This project's dependencies
+psycopg2
+venusian

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,0 +1,4 @@
+# The project's testing dependencies...
+pytest
+pytest-cov
+mock==1.0.1;python_version<="2.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,7 @@ versionfile_source = cnxdb/_version.py
 versionfile_build = cnxdb/_version.py
 tag_prefix =
 parentdir_prefix =
+
+[tool:pytest]
+norecursedirs = build dist *.egg-info requirements .state .tox
+addopts = -v --cov-config .coveragerc --cov=cnxdb

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,14 @@
 [aliases]
 test=pytest
 
+[flake8]
+exclude = *.egg,.state,.tox,cnxdb/migrations,docs/conf.py,cnxdb/archive-sql/schema/*.py
+select = E,W,F,N
+
+[doc8]
+ignore-path = docs/build/
+allow-long-titles = true
+
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py3
 
 [testenv]
 deps=
-    pytest
-    mock==1.0.1;python_version<="2.7"
+    -r{toxinidir}/requirements/tests.txt
 commands=py.test


### PR DESCRIPTION
This introduces **an interface for testing, linting and building the docs**. (Future PRs add to this set of available actions.)

'Make' is used because it's stable as a rock, fits this use case perfectly as a build tool for working on things based on file artifacts and it's easy to learn due to the narrow scope of what it solves.

Also, 'Make' a well supported and a tool that is utilized by several open source communities. Here are a few things this does for us: 1) Shows what commands are being run 2) compiles a set of commands into a recipe for conditional use based on build artifacts 3) abstracts the procedure, which makes it easier to adjust without influencing workflow, etc.


