### PR TITLE
Notify post_publication with payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 	python3 -m venv $(VENV_EXTRA_ARGS) $(STATEDIR)/env
 endif
 	# Upgrade tooling requirements
-	$(BINDIR)/python -m pip install --upgrade pip setuptools wheel
+	$(BINDIR)/python -m pip install --upgrade pip setuptools wheel tox
 
 	# Install requirements
 	$(BINDIR)/python -m pip install $(foreach req,$(_REQUIREMENTS_FILES),-r $(req))
@@ -109,7 +109,7 @@ help-tests :
 	@echo "    (see also setup.cfg's pytest configuration)"
 
 tests : $(STATEDIR)/env/pyvenv.cfg
-	tox $(TESTS_EXTRA_ARGS) $(TESTS)
+	$(BINDIR)/tox $(TESTS_EXTRA_ARGS) $(TESTS)
 
 # /Tests
 

--- a/cnxdb/archive-sql/schema/triggers.sql
+++ b/cnxdb/archive-sql/schema/triggers.sql
@@ -92,7 +92,7 @@ CREATE TRIGGER delete_from_latest_version
 
 CREATE OR REPLACE FUNCTION post_publication() RETURNS trigger AS $$
 BEGIN
-  NOTIFY post_publication;
+  PERFORM pg_notify('post_publication', '{"module_ident": '||NEW.module_ident||', "ident_hash": "'||ident_hash(NEW.uuid, NEW.major_version, NEW.minor_version)||'", "timestamp": "'||CURRENT_TIMESTAMP||'"}');
   RETURN NEW;
 END;
 $$ LANGUAGE 'plpgsql';

--- a/cnxdb/tests/cli/test_main.py
+++ b/cnxdb/tests/cli/test_main.py
@@ -31,11 +31,8 @@ def test_init(connection_string_parts):
 
     with psycopg2.connect(**connection_string_parts) as conn:
         with conn.cursor() as cursor:
-            cursor.execute("SELECT table_name "
-                           "FROM information_schema.tables "
-                           "ORDER BY table_name")
-            tables = [table_name for (table_name,) in cursor.fetchall()
-                      if table_name_filter(table_name)]
+            tables = testing.get_database_table_names(cursor,
+                                                      table_name_filter)
 
     assert 'modules' in tables
     assert 'pending_documents' in tables

--- a/cnxdb/tests/cli/test_main.py
+++ b/cnxdb/tests/cli/test_main.py
@@ -18,7 +18,7 @@ def _translate_parts_to_args(parts):
 
 
 @pytest.mark.usefixtures('db_wipe')
-def test_init(connection_string_parts):
+def test_init(connection_string_parts, db_cursor_without_db_init):
     from cnxdb.cli.main import main
     args = ['init'] + _translate_parts_to_args(connection_string_parts)
     return_code = main(args)
@@ -29,10 +29,8 @@ def test_init(connection_string_parts):
         return (not table_name.startswith('pg_') and
                 not table_name.startswith('_pg_'))
 
-    with psycopg2.connect(**connection_string_parts) as conn:
-        with conn.cursor() as cursor:
-            tables = testing.get_database_table_names(cursor,
-                                                      table_name_filter)
+    cursor = db_cursor_without_db_init
+    tables = testing.get_database_table_names(cursor, table_name_filter)
 
     assert 'modules' in tables
     assert 'pending_documents' in tables

--- a/cnxdb/tests/conftest.py
+++ b/cnxdb/tests/conftest.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
+import psycopg2
 import pytest
 
-from .testing import get_connection_string, get_connection_string_parts
+from .testing import (
+    get_connection_string,
+    get_connection_string_parts,
+    get_database_table_names,
+)
 
 
 @pytest.fixture
@@ -16,17 +21,27 @@ def connection_string():
     return get_connection_string()
 
 
+def _db_wipe(connection_string):
+    """Removes the schema from the database"""
+    with psycopg2.connect(connection_string) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("DROP SCHEMA public CASCADE; "
+                           "CREATE SCHEMA public")
+            cursor.execute("DROP SCHEMA IF EXISTS venv CASCADE")
+
+
 @pytest.fixture
-def db_wipe(connection_string, request):
+def db_wipe(connection_string, request, db_cursor_without_db_init):
     """Cleans up the database after a test run"""
-    import psycopg2
+    cursor = db_cursor_without_db_init
+    tables = get_database_table_names(cursor)
+    # Assume that if db_wipe is used it means we want to start fresh as well.
+    if 'modules' in tables:
+        _db_wipe(connection_string)
 
     def finalize():
-        with psycopg2.connect(connection_string) as conn:
-            with conn.cursor() as cursor:
-                cursor.execute("DROP SCHEMA public CASCADE; "
-                               "CREATE SCHEMA public")
-                cursor.execute("DROP SCHEMA IF EXISTS venv CASCADE")
+        _db_wipe(connection_string)
+
     request.addfinalizer(finalize)
 
 
@@ -38,6 +53,47 @@ def db_init(connection_string):
 
 
 @pytest.fixture
-def db_init_and_wipe(db_init, db_wipe):
+def db_init_and_wipe(db_wipe, db_init):
     """Combination of the initialization and wiping procedures."""
+    # The argument order, 'wipe' then 'init' is important, because
+    #   db_wipe assumes you want to start with a clean database.
     pass
+
+
+@pytest.fixture
+def db_cursor_without_db_init(connection_string):
+    """Creates a database connection and cursor"""
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+    yield cursor
+    cursor.close()
+    conn.close()
+
+
+# Used to flag whether tests have been run before
+_db_cursor__first_run = True
+
+
+@pytest.fixture
+def db_cursor(connection_string):
+    """Creates a database connection and cursor"""
+    global _db_cursor__first_run
+
+    with psycopg2.connect(connection_string) as conn:
+        with conn.cursor() as cursor:
+            tables = get_database_table_names(cursor)
+    # Use the database if it exists, otherwise initialize it
+    if _db_cursor__first_run:
+        _db_wipe(connection_string)
+        db_init(connection_string)
+        _db_cursor__first_run = False
+    elif 'modules' not in tables:
+        db_init(connection_string)
+
+    # Create a new connection to activate the virtual environment
+    # as it would normally be used.
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+    yield cursor
+    cursor.close()
+    conn.close()

--- a/cnxdb/tests/init/test_main.py
+++ b/cnxdb/tests/init/test_main.py
@@ -9,7 +9,7 @@ from .. import testing
 
 
 @pytest.mark.usefixtures('db_wipe')
-def test_db_init(connection_string):
+def test_db_init(connection_string, db_cursor_without_db_init):
     from cnxdb.init.main import init_db
     init_db(connection_string)
 
@@ -17,10 +17,8 @@ def test_db_init(connection_string):
         return (not table_name.startswith('pg_') and
                 not table_name.startswith('_pg_'))
 
-    with psycopg2.connect(connection_string) as conn:
-        with conn.cursor() as cursor:
-            tables = testing.get_database_table_names(cursor,
-                                                      table_name_filter)
+    cursor = db_cursor_without_db_init
+    tables = testing.get_database_table_names(cursor, table_name_filter)
 
     assert 'modules' in tables
     assert 'pending_documents' in tables

--- a/cnxdb/tests/init/test_main.py
+++ b/cnxdb/tests/init/test_main.py
@@ -19,11 +19,8 @@ def test_db_init(connection_string):
 
     with psycopg2.connect(connection_string) as conn:
         with conn.cursor() as cursor:
-            cursor.execute("SELECT table_name "
-                           "FROM information_schema.tables "
-                           "ORDER BY table_name")
-            tables = [table_name for (table_name,) in cursor.fetchall()
-                      if table_name_filter(table_name)]
+            tables = testing.get_database_table_names(cursor,
+                                                      table_name_filter)
 
     assert 'modules' in tables
     assert 'pending_documents' in tables

--- a/cnxdb/tests/schema/test_triggers.py
+++ b/cnxdb/tests/schema/test_triggers.py
@@ -2,9 +2,21 @@
 import json
 import uuid
 
+import pytest
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
+from .. import testing
 
+
+# Note, the triggers are only python 2.x compatible. It's assumed,
+# at least for now, that in-database logic (i.e. triggers) are only
+# run within a python2 environment. This product is to be setup in a
+# production environment running within the database under python2 and
+# optionally running within application code under either python2 or python3.
+
+
+@pytest.mark.skipif(testing.is_py3(),
+                    reason="triggers are only python2.x compat")
 class TestPostPublication:
 
     channel = 'post_publication'

--- a/cnxdb/tests/schema/test_triggers.py
+++ b/cnxdb/tests/schema/test_triggers.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import json
+import uuid
+
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+
+class TestPostPublication:
+
+    channel = 'post_publication'
+
+    def _make_one(self, cursor):
+        """Insert the minimum necessary for creating a 'modules' entry."""
+        uuid_ = str(uuid.uuid4())
+        cursor.execute("INSERT INTO document_controls (uuid) VALUES (%s)",
+                       (uuid_,))
+        # The important bit here is `stateid = 5`
+        cursor.execute("""\
+        INSERT INTO modules
+          (module_ident, portal_type, uuid, name, licenseid, doctype, stateid)
+        VALUES
+          (DEFAULT, 'Collection', %s, 'Physics: An Introduction', 11, '', 5)
+        RETURNING
+          module_ident,
+          ident_hash(uuid, major_version, minor_version)""",
+                       (uuid_,))
+        module_ident, ident_hash = cursor.fetchone()
+        cursor.connection.commit()
+        return (module_ident, ident_hash)
+
+    def test_payload(self, db_cursor):
+        # Listen for notifications
+        db_cursor.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        db_cursor.execute('LISTEN {}'.format(self.channel))
+        db_cursor.connection.commit()
+
+        module_ident, ident_hash = self._make_one(db_cursor)
+
+        # Commit and poll to get the notifications
+        db_cursor.connection.commit()
+        db_cursor.connection.poll()
+        notify = db_cursor.connection.notifies.pop(0)
+
+        # Test the contents of the notification
+        assert notify.channel == self.channel
+        payload = json.loads(notify.payload)
+        assert payload['module_ident'] == module_ident
+        assert payload['ident_hash'] == ident_hash
+        assert payload['timestamp']

--- a/cnxdb/tests/testing.py
+++ b/cnxdb/tests/testing.py
@@ -73,6 +73,11 @@ def is_venv():
     return hasattr(sys, 'real_prefix')
 
 
+def is_py3():
+    """Returns a boolean value if running under python3.x"""
+    return sys.version_info > (3,)
+
+
 def is_db_local():
     """Returns a boolean telling whether the database is local or not."""
     return get_connection_string_parts()['host'] == 'localhost'
@@ -100,5 +105,6 @@ __all__ = (
     'get_connection_string',
     'get_database_table_names',
     'is_db_local',
+    'is_py3',
     'is_venv',
     )

--- a/cnxdb/tests/testing.py
+++ b/cnxdb/tests/testing.py
@@ -78,10 +78,27 @@ def is_db_local():
     return get_connection_string_parts()['host'] == 'localhost'
 
 
+def _default_table_name_filter(table_name):
+    return (not table_name.startswith('pg_') and
+            not table_name.startswith('_pg_'))
+
+
+def get_database_table_names(cursor,
+                             table_name_filter=_default_table_name_filter):
+    """Query for the names of all the tables in the database."""
+    cursor.execute("SELECT table_name "
+                   "FROM information_schema.tables "
+                   "ORDER BY table_name")
+    tables = [table_name for (table_name,) in cursor.fetchall()
+              if table_name_filter(table_name)]
+    return list(tables)
+
+
 __all__ = (
     'db_connect',
     'db_connection_factory',
     'get_connection_string',
+    'get_database_table_names',
     'is_db_local',
     'is_venv',
     )

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,5 @@
 pytest
 pytest-cov
 mock==1.0.1;python_version<="2.7"
+# FIXME circular dependency here...
+cnx-archive

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ parentdir_prefix =
 
 [tool:pytest]
 norecursedirs = build dist *.egg-info requirements .state .tox
-addopts = -v --cov-config .coveragerc --cov=cnxdb
+addopts = -rxs -v --cov-config .coveragerc --cov=cnxdb


### PR DESCRIPTION
This will now send the module_ident and ident_hash as part of the
notification. This will allow listeners/subscribers to use this detailed
information to take action on the event rather than query for the data
after a blank notification.