### PR TITLE
Don't return chapters (subcollections) in search

### DIFF
--- a/cnxdb/archive-sql/search/query.sql
+++ b/cnxdb/archive-sql/search/query.sql
@@ -64,7 +64,7 @@ FROM
   derived_weighted_query_results AS wqr
 WHERE
   wqr.module_ident = lm.module_ident
-  AND lm.portal_type != 'CompositeModule'
+  AND lm.portal_type not in  ('CompositeModule','SubCollection')
   {filters}
   {groupby}
 ORDER BY {sorts}


### PR DESCRIPTION
currently errors if a chapter gets matched. Some day, may want to return chapters, but this will do for first release.