### PR TITLE
Add association table for celery results to modules

### DIFF
--- a/cnxdb/migrations/20170530185035_switch_to_channel_processing.py
+++ b/cnxdb/migrations/20170530185035_switch_to_channel_processing.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("DROP TABLE post_publications")
+    cursor.execute("""\
+CREATE TABLE document_baking_result_associations (
+  -- This associates the modules.module_ident with the celery result id.
+  "module_ident" INTEGER NOT NULL,
+  -- We loosely associate the result_id, because it could be in the database
+  -- or in some other storage service depending on the configuration.
+  "result_id" UUID NOT NULL,
+  "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY ("module_ident", "result_id"),
+  FOREIGN KEY ("module_ident") REFERENCES modules ("module_ident")
+);
+""")
+
+
+def down(cursor):
+    cursor.execute("DROP TABLE document_baking_result_associations")
+    cursor.execute("""\
+CREATE TABLE post_publications (
+  "module_ident" INTEGER NOT NULL,
+  "state" post_publication_states NOT NULL,
+  "state_message" TEXT,
+  "timestamp" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY ("module_ident") REFERENCES modules ("module_ident")
+);
+""")

--- a/cnxdb/publishing-sql/schema-tables.sql
+++ b/cnxdb/publishing-sql/schema-tables.sql
@@ -111,10 +111,13 @@ CREATE TABLE api_keys (
 );
 
 
-CREATE TABLE post_publications (
+CREATE TABLE document_baking_result_associations (
+  -- This associates the modules.module_ident with the celery result id.
   "module_ident" INTEGER NOT NULL,
-  "state" post_publication_states NOT NULL,
-  "state_message" TEXT,
-  "timestamp" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  -- We loosely associate the result_id, because it could be in the database
+  -- or in some other storage service depending on the configuration.
+  "result_id" UUID NOT NULL,
+  "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY ("module_ident", "result_id"),
   FOREIGN KEY ("module_ident") REFERENCES modules ("module_ident")
 );


### PR DESCRIPTION
Drop the `post_publications` table in favor of a simple association table for the baking process. This associates the `modules.module_ident` with the `results_id` of a `celery.results.AsyncResult`, which may or may not be stored in the same database depending on how celery has been configured to store the results.