### PR TITLE
fix minor versions and current_modules view

### DIFF
--- a/cnxdb/migrations/20170811000000_minor-version-correction.py
+++ b/cnxdb/migrations/20170811000000_minor-version-correction.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    """Fix bad minor_versions for major_version = 2 modules"""
+
+    cursor.execute("""CREATE SCHEMA IF NOT EXISTS datamigrations""")
+
+    cursor.execute("""
+    CREATE TABLE datamigrations.bad_minor_vers as SELECT * from modules
+        WHERE substring(version,0,strpos(version,'.'))::int +
+        substring(version,strpos(version,'.')+1)::int - 1 != major_version;
+
+""")
+    cursor.execute("""
+    UPDATE modules SET major_version =
+                     substring(version,0,strpos(version,'.'))::int +
+                     substring(version,strpos(version,'.')+1)::int - 1
+      WHERE substring(version,0,strpos(version,'.'))::int +
+      substring(version,strpos(version,'.')+1)::int - 1 != major_version;
+
+""")
+
+
+def down(cursor):
+    """Put the bad values back?!"""
+    cursor.execute("""UPDATE modules
+        SET major_version = b.major_version
+        FROM datamigrations.bad_minor_vers b
+        WHERE modules.module_ident = b.module_ident;
+    DROP TABLE datamigrations.bad_minor_vers;
+""")

--- a/cnxdb/migrations/20170812000000_current-modules-view.py
+++ b/cnxdb/migrations/20170812000000_current-modules-view.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    """Replace current_modules with correct logic"""
+    cursor.execute("""
+DROP VIEW current_modules;
+CREATE OR REPLACE VIEW current_modules AS
+WITH latest_idents (module_ident) AS (
+          SELECT module_ident FROM modules m2 join modulestates ms
+                on m2.stateid = ms.stateid
+                WHERE m2.major_version = (
+                    SELECT max(major_version) FROM modules m3
+                        WHERE m2.uuid = m3.uuid
+                )
+                AND
+                (m2.minor_version IS NULL OR
+                 m2.minor_version = (
+                    SELECT max(minor_version) FROM modules m4
+                        WHERE m2.uuid = m4.uuid AND
+                        m2.major_version = m4.major_version
+                    )
+                )
+                AND ms.statename = 'current'
+        )
+SELECT m.* FROM latest_idents li JOIN modules m
+ON m.module_ident = li.module_ident;
+""")
+
+    cursor.execute("""UPDATE modules SET stateid = 1 WHERE stateid IS NULL""")
+
+    cursor.execute("""CREATE TABLE datamigrations.corrected_latest AS
+            SELECT * FROM current_modules cm
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM latest_modules lm
+                        WHERE cm.module_ident = lm.module_ident)""")
+
+    cursor.execute("""CREATE TABLE datamigrations.wrong_latest AS
+            SELECT * FROM latest_modules WHERE uuid IN
+            (SELECT uuid FROM datamigrations.corrected_latest);
+            DELETE FROM latest_modules WHERE uuid IN
+            (SELECT uuid FROM datamigrations.corrected_latest);
+            INSERT INTO latest_modules
+                SELECT * from datamigrations.corrected_latest""")
+
+
+def down(cursor):
+    """Put back broken definition"""
+    cursor.execute("""
+SELECT m.module_ident,
+    m.portal_type,
+    m.moduleid,
+    m.uuid,
+    m.version,
+    m.name,
+    m.created,
+    m.revised,
+    m.abstractid,
+    m.licenseid,
+    m.doctype,
+    m.submitter,
+    m.submitlog,
+    m.stateid,
+    m.parent,
+    m.language,
+    m.authors,
+    m.maintainers,
+    m.licensors,
+    m.parentauthors,
+    m.google_analytics,
+    m.buylink,
+    m.major_version,
+    m.minor_version,
+    m.print_style
+   FROM modules m
+  WHERE m.module_ident = (( SELECT max(modules.module_ident) AS max
+           FROM modules
+          WHERE m.moduleid = modules.moduleid));
+""")
+
+    cursor.execute("""DELETE FROM latest_modules WHERE uuid IN
+            (SELECT uuid FROM datamigrations.wrong_latest);
+            INSERT INTO latest_modules
+                SELECT * from datamigrations.wrong_latest;
+            DROP TABLE datamigrations.wrong_latest;
+            DROP TABLE datamigrations.corrected_latest;""")


### PR DESCRIPTION
Clean up some issues w/ production data, and correct the logic used in the current_modules view. That view and the trigger-maintained latest_modules should always be identical, by design. The view is used by one trigger (the delete_from_latest trigger on the modules table) to refill latest if the latest version of a given document is deleted. A rare event, but needs coverage.

It occurs to me that the policy I defined above, as well as "latest_modules is to be maintained by triggers only  - all DML occurs on modules table" should probably be written down somewhere.