### PR TITLE
Fix typo in migration update_latest_trigger

### DIFF
--- a/cnxdb/migrations/20170821163229_update_latest_trigger.py
+++ b/cnxdb/migrations/20170821163229_update_latest_trigger.py
@@ -64,7 +64,7 @@ END;
 
 
 def down(cursor):
-    cursor.exeucte("""\
+    cursor.execute("""\
 CREATE OR REPLACE FUNCTION update_latest() RETURNS trigger AS '
 BEGIN
   IF (TG_OP = ''INSERT'' OR TG_OP = ''UPDATE'') AND


### PR DESCRIPTION
cursor.exeucte -> cursor.execute