### PR TITLE
CI/dev user shared integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   # This is the same as `python setup.py test` with a coverage wrapper.
   - py.test
   # Test migrations
-  - ./.travis_test_migrations.sh
+  - script/ci_test_migrations.sh
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/script/ci_test_migrations.sh
+++ b/script/ci_test_migrations.sh
@@ -6,7 +6,12 @@ git fetch origin master
 first_commit=$(git log --format='%h' --reverse FETCH_HEAD.. | head -1)
 
 # keep track of which branch we are on, so we can go back to it later
-current_branch=$(git symbolic-ref --short HEAD)
+if [ -z "$CI" ]
+then
+    current_commit=$(git symbolic-ref --short HEAD)
+else
+    current_commit=$(git log --format='%h' | head -1)
+fi
 
 if [ -z "$first_commit" ]
 then
@@ -31,7 +36,7 @@ dbmigrator --db-connection-string='dbname=testing user=tester' init
 pg_dump -s 'dbname=testing user=tester' >old_schema.sql
 
 # go back to the branch HEAD
-git checkout $current_branch
+git checkout $current_commit
 pip install .
 
 # check the number of migrations that are going to run
@@ -61,6 +66,7 @@ pg_dump -s 'dbname=testing user=tester' >new_schema.sql
 
 # Put dev environment back, if not on Travis
 if [ -z "$CI" ]
+then
     pip install -e .
 fi
 


### PR DESCRIPTION
    * use branch name instead of commit hash when running non-CI
    * detect (lack of) CI and restore develop install
    * move to project canonical script location

Some changes to make the script easier to use for devs, so we're more likely to run it before asking travis to. :-)