### PR TITLE
Use super user to replace plpythonu function in migration

### DIFF
--- a/cnxdb/migrations/20170815141631_subcol-uuids-fn.py
+++ b/cnxdb/migrations/20170815141631_subcol-uuids-fn.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 
 
+from dbmigrator import super_user
+
+
 # Uncomment should_run if this is a repeat migration
 # def should_run(cursor):
 #     # TODO return True if migration should run
 
 
 def up(cursor):
-    # TODO migration code
-
-    cursor.execute('''
+    with super_user() as super_cursor:
+        super_cursor.execute('''
 CREATE OR REPLACE FUNCTION subcol_uuids(uuid uuid, version text) RETURNS VOID
  LANGUAGE sql
 AS $function$
@@ -126,7 +128,8 @@ $function$
 
 def down(cursor):
     # rollback to broken function def
-    cursor.execute('''
+    with super_user() as super_cursor:
+        super_cursor.execute('''
 CREATE OR REPLACE FUNCTION subcol_uuids(uuid uuid, version text)
  RETURNS void
  LANGUAGE sql


### PR DESCRIPTION
We ran the migration on QA and got this error:

```
Traceback (most recent call last):\n
  File \"/var/cnx/venvs/publishing/bin/dbmigrator\", line 11, in <module>\n
    sys.exit(main())\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/cli.py\", line 104, in main\n
    return args['cmmd'](**args)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 145, in wrapper\n
    return func(cursor, *args, **kwargs)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/commands/migrate.py\", line 32, in cli_command\n
    run_deferred)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 227, in compare_schema\n
    callback(*args, **kwargs)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 257, in run_migration\n
    migration.up(cursor)\n
  File \"../../var/cnx/venvs/publishing/src/cnx-db/cnxdb/migrations/20170912134157_shred-colxml-uuids.py\", line 20, in up\n
    cursor.execute(f.read())\n
psycopg2.ProgrammingError: permission denied for language plpythonu
```