### PR TITLE
Use super user to create plpythonu function in migration

### DIFF
--- a/cnxdb/migrations/20170912134157_shred-colxml-uuids.py
+++ b/cnxdb/migrations/20170912134157_shred-colxml-uuids.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-
 from contextlib import contextmanager
+
+from dbmigrator import super_user
 
 
 @contextmanager
@@ -15,16 +16,17 @@ def open_here(filepath, *args, **kwargs):
 
 
 def up(cursor):
-
-    with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
-        cursor.execute(f.read())
-    cursor.execute('drop function shred_collxml(text)')
-    cursor.execute('drop function shred_collxml(int)')
-    cursor.execute('drop function shred_collxml(int,int)')
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+        super_cursor.execute('drop function shred_collxml(text)')
+        super_cursor.execute('drop function shred_collxml(int)')
+        super_cursor.execute('drop function shred_collxml(int,int)')
 
 
 def down(cursor):
-    with open_here('shred_collxml_20170912134157_pre.sql', 'rb') as f:
-        cursor.execute(f.read())
-    cursor.execute('drop function shred_collxml(text, integer)')
-    cursor.execute('drop function shred_collxml(integer, integer, bool)')
+    with super_user() as super_cursor:
+        with open_here('shred_collxml_20170912134157_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+        super_cursor.execute('drop function shred_collxml(text, integer)')
+        super_cursor.execute('drop function shred_collxml(integer, integer, bool)')


### PR DESCRIPTION
We're seeing this error when deploying to QA:

```
Traceback (most recent call last):\n
  File \"/var/cnx/venvs/publishing/bin/dbmigrator\", line 11, in <module>\n
    sys.exit(main())\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/cli.py\", line 104, in main\n
    return args['cmmd'](**args)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 145, in wrapper\n
    return func(cursor, *args, **kwargs)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/commands/migrate.py\", line 32, in cli_command\n
    run_deferred)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 227, in compare_schema\n
    callback(*args, **kwargs)\n
  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 257, in run_migration\n
    migration.up(cursor)\n
  File \"../../var/cnx/venvs/publishing/src/cnx-db/cnxdb/migrations/20170912134157_shred-colxml-uuids.py\", line 20, in up\n
    cursor.execute(f.read())\n
psycopg2.ProgrammingError: permission denied for language plpythonu
```