### PR TITLE
Add IF EXISTS to DROP CONSTRAINT in migration

### DIFF
--- a/cnxdb/migrations/20170912184444_foreign-key-idx.py
+++ b/cnxdb/migrations/20170912184444_foreign-key-idx.py
@@ -42,7 +42,7 @@ def up(cursor):
         ON DELETE CASCADE;
 
         ALTER TABLE collated_file_associations DROP CONSTRAINT
-        collated_file_associations_fileid_fkey;
+        IF EXISTS collated_file_associations_fileid_fkey;
 
         ALTER TABLE collated_file_associations ADD FOREIGN KEY
         (fileid) REFERENCES files(fileid)
@@ -180,7 +180,7 @@ def down(cursor):
         (item) REFERENCES modules(module_ident);
 
         ALTER TABLE collated_file_associations DROP CONSTRAINT
-        collated_file_associations_fileid_fkey;
+        IF EXISTS collated_file_associations_fileid_fkey;
 
         ALTER TABLE collated_file_associations ADD FOREIGN KEY
         (fileid) REFERENCES files(fileid)


### PR DESCRIPTION
The constraint `collated_file_associations_fileid_fkey` appears to be in
the production database but not in the QA database or the schema.

```
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/bin/dbmigrator", line 11, in <module>
    sys.exit(main())
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/cli.py", line 104, in main
    return args['cmmd'](**args)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py", line 145, in wrapper
    return func(cursor, *args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/commands/migrate.py", line 32, in cli_command
    run_deferred)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py", line 227, in compare_schema
    callback(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py", line 257, in run_migration
    migration.up(cursor)
  File "../../var/cnx/venvs/publishing/src/cnx-db/cnxdb/migrations/20170912184444_foreign-key-idx.py", line 49, in up
    ON DELETE CASCADE""")
psycopg2.ProgrammingError: constraint "collated_file_associations_fileid_fkey" of relation "collated_file_associations" does not exist
```