### PR TITLE
migration for code to fix double trigger when rebaking

### DIFF
--- a/cnxdb/migrations/20170918181635_rebake-double-trigger.py
+++ b/cnxdb/migrations/20170918181635_rebake-double-trigger.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION rebake()
+     RETURNS trigger
+     LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      UPDATE modules SET stateid = 5
+        WHERE module_ident = NEW.module_ident and stateid not in (5, 6);
+      RETURN NEW;
+    END;
+    $$;
+    """)
+
+
+def down(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION rebake()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        UPDATE modules SET stateid = 5
+          WHERE module_ident = NEW.module_ident;
+        RETURN NEW;
+      END;
+    $$
+    """)


### PR DESCRIPTION
Code to fix double-trigger-when-rebaking was committed a month ago, without a migration. This is the matching migration. Because the code is already on master, this will fail the migration test script, since old_schema == new_schema