### PR TITLE
Use postgres super user in migrations that require it

### DIFF
--- a/cnxdb/migrations/20160723123620_add_sql_function_strip_html.py
+++ b/cnxdb/migrations/20160723123620_add_sql_function_strip_html.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from dbmigrator import super_user
+
 
 def up(cursor):
-    cursor.execute("""\
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
 CREATE OR REPLACE FUNCTION strip_html(html_text TEXT)
   RETURNS text
 AS $$
@@ -13,4 +16,5 @@ $$ LANGUAGE plpythonu IMMUTABLE;
 
 
 def down(cursor):
-    cursor.execute("DROP FUNCTION IF EXISTS strip_html(TEXT)")
+    with super_user() as super_cursor:
+        super_cursor.execute("DROP FUNCTION IF EXISTS strip_html(TEXT)")

--- a/cnxdb/migrations/20160723124137_add_modules_strip_html_name_index.py
+++ b/cnxdb/migrations/20160723124137_add_modules_strip_html_name_index.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from dbmigrator import super_user
+
 
 def up(cursor):
-    cursor.execute("""\
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
 CREATE EXTENSION pg_trgm;
 CREATE INDEX modules_strip_html_name_trgm_gin ON modules \
     USING gin(strip_html(name) gin_trgm_ops);
@@ -10,7 +13,8 @@ CREATE INDEX modules_strip_html_name_trgm_gin ON modules \
 
 
 def down(cursor):
-    cursor.execute("""\
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
 DROP INDEX IF EXISTS modules_strip_html_name_trgm_gin;
 DROP EXTENSION IF EXISTS pg_trgm;
 """)

--- a/cnxdb/migrations/20170201213850_add-subcollection-metadata.py
+++ b/cnxdb/migrations/20170201213850_add-subcollection-metadata.py
@@ -3,6 +3,8 @@ import os
 
 from contextlib import contextmanager
 
+from dbmigrator import super_user
+
 
 @contextmanager
 def open_here(filepath, *args, **kwargs):
@@ -17,12 +19,13 @@ def open_here(filepath, *args, **kwargs):
 def up(cursor):
     """Add subcol metadata support to shredding and data upgrades"""
 
-    cursor.execute("""
+    with super_user() as super_cursor:
+        super_cursor.execute("""
 CREATE FUNCTION uuid5(namespace uuid, name text) RETURNS uuid
     LANGUAGE plpythonu
     AS $_$ import uuid; return uuid.uuid5(uuid.UUID(namespace), name) $_$;""")
 
-    cursor.execute("""
+        super_cursor.execute("""
 CREATE OR REPLACE FUNCTION public.is_baked(col_uuid uuid, col_ver text)
  RETURNS boolean
  LANGUAGE sql
@@ -34,19 +37,19 @@ SELECT bool_or(is_collated)
           module_version(major_version, minor_version) = col_ver
 $function$;""")
 
-    with open_here('../archive-sql/schema/subcol_uuids_func.sql', 'rb') as f:
-        cursor.execute(f.read())
+        with open_here('../archive-sql/schema/subcol_uuids_func.sql',
+                       'rb') as f:
+            super_cursor.execute(f.read())
 
-    with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
-        cursor.execute(f.read())
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
 
 
 def down(cursor):
-    # TODO rollback code
+    with super_user() as super_cursor:
+        super_cursor.execute('drop function uuid5(uuid, text)')
+        super_cursor.execute('drop function is_baked(uuid, text)')
+        super_cursor.execute('drop function subcol_uuids(text, text)')
 
-    cursor.execute('drop function uuid5(uuid, text)')
-    cursor.execute('drop function is_baked(uuid, text)')
-    cursor.execute('drop function subcol_uuids(text, text)')
-
-    with open_here('shred_collxml_20170201213850_pre.sql', 'rb') as f:
-        cursor.execute(f.read())
+        with open_here('shred_collxml_20170201213850_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())

--- a/cnxdb/migrations/20170208213802_ident-hash-func.py
+++ b/cnxdb/migrations/20170208213802_ident-hash-func.py
@@ -3,6 +3,8 @@ import os
 
 from contextlib import contextmanager
 
+from dbmigrator import super_user
+
 
 @contextmanager
 def open_here(filepath, *args, **kwargs):
@@ -15,9 +17,9 @@ def open_here(filepath, *args, **kwargs):
 
 
 def up(cursor):
-
-    with open_here('../archive-sql/schema/functions.sql', 'rb') as f:
-        cursor.execute(f.read())
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/functions.sql', 'rb') as f:
+            super_cursor.execute(f.read())
 
     cursor.execute("""
 CREATE INDEX modules_ident_hash on modules(ident_hash(uuid, major_version, minor_version));
@@ -25,7 +27,8 @@ CREATE INDEX modules_short_ident_hash on modules(short_ident_hash(uuid, major_ve
 
 
 def down(cursor):
-    # TODO rollback code
-
-    cursor.execute('drop function ident_hash(uuid, int, int) CASCADE')
-    cursor.execute('drop function short_ident_hash(uuid, int, int) CASCADE')
+    with super_user() as super_cursor:
+        super_cursor.execute(
+            'drop function ident_hash(uuid, int, int) CASCADE')
+        super_cursor.execute(
+            'drop function short_ident_hash(uuid, int, int) CASCADE')


### PR DESCRIPTION
- Create plpython function with super user in migration

  When running the migrations 20160723123620_add_sql_function_strip_html,
  20170201213850_add-subcollection-metadata,
  20170208213802_ident-hash-func against a database where
  the user is not a super user, we see this error:
  
  ```
  psycopg2.ProgrammingError: permission denied for language plpythonu
  ```

- Create extension pg_trgm with super user in migration

  When running the migration 20160723124137
  add_modules_strip_html_name_index against a database where the user is
  not a super user, we see this error:
  
  ```
  psycopg2.ProgrammingError: permission denied to create extension "pg_trgm"
  ```
