### PR TITLE
featured books table migration

### DIFF
--- a/cnxdb/migrations/20170918131724_add_featured_books.py
+++ b/cnxdb/migrations/20170918131724_add_featured_books.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""\
+CREATE TABLE featured_books (
+    "uuid" UUID NOT NULL,
+    "tagid" TEXT
+);""")
+    cursor.execute("""\
+INSERT INTO featured_books (uuid, tagid)
+    SELECT uuid, version FROM modules
+        JOIN moduletags ON moduletags.module_ident = modules.module_ident
+        WHERE moduletags.tagid=9;
+""")
+
+def down(cursor):
+    cursor.execute("DROP TABLE featured_books")

--- a/cnxdb/migrations/20170918131724_add_featured_books.py
+++ b/cnxdb/migrations/20170918131724_add_featured_books.py
@@ -5,11 +5,12 @@ def up(cursor):
     cursor.execute("""\
 CREATE TABLE featured_books (
     "uuid" UUID NOT NULL,
-    "tagid" TEXT
+    "major_version" INT,
+    "minor_version" INT
 );""")
     cursor.execute("""\
-INSERT INTO featured_books (uuid, tagid)
-    SELECT uuid, version FROM modules
+INSERT INTO featured_books (uuid, major_version, minor_version)
+    SELECT uuid, major_version, minor_version FROM modules
         JOIN moduletags ON moduletags.module_ident = modules.module_ident
         WHERE moduletags.tagid=9;
 """)


### PR DESCRIPTION
Adding the `featured_books` table to the migrations.

This table is already on production, but not being used. The current one uses moduleid and tagid instead of uuid and tagid.