### PR TITLE
don't copy stateid from collection when inserting subcollections

### DIFF
--- a/cnxdb/archive-sql/schema/shred_collxml.py
+++ b/cnxdb/archive-sql/schema/shred_collxml.py
@@ -55,13 +55,13 @@ WHERE nodeid = %s"""
 SUBCOL_INS="""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', 'col'||nextval('collectionid_seq'), %s, uuid5(uuid, %s),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style
@@ -71,13 +71,13 @@ WHERE nodeid = %s RETURNING module_ident"""
 SUBCOL_NEW_VERSION="""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', %s, %s, uuid5(uuid, %s),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style

--- a/cnxdb/migrations/20170922150407_shred-collxml-stateid.py
+++ b/cnxdb/migrations/20170922150407_shred-collxml-stateid.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import os
+from contextlib import contextmanager
+
+from dbmigrator import super_user
+
+
+@contextmanager
+def open_here(filepath, *args, **kwargs):
+    """open a file relative to this files location"""
+
+    here = os.path.abspath(os.path.dirname(__file__))
+    fp = open(os.path.join(here, filepath), *args, **kwargs)
+    yield fp
+    fp.close()
+
+
+def up(cursor):
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+
+
+def down(cursor):
+    with super_user() as super_cursor:
+        with open_here('shred_collxml_20170922150407_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())

--- a/cnxdb/migrations/shred_collxml_20170922150407_pre.sql
+++ b/cnxdb/migrations/shred_collxml_20170922150407_pre.sql
@@ -67,13 +67,13 @@ WHERE nodeid = $2""", ("text","int"))
 SUBCOL_INS=plpy.prepare("""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', 'col'||nextval('collectionid_seq'), $1, uuid5(uuid, $1),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style
@@ -83,13 +83,13 @@ WHERE nodeid = $2  RETURNING module_ident""", ("text","int"))
 SUBCOL_NEW_VERSION=plpy.prepare("""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', $3, $1, uuid5(uuid, $1),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style


### PR DESCRIPTION
 avoids trying to bake them - they "fail fast (no recipe)" but fill up the status view page with noise.