### PR TITLE
Remove derived trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   # This is the same as `python setup.py test` with a coverage wrapper.
   - py.test
   # Test migrations
-  - ./.travis_test_migrations.sh
+  - script/ci_test_migrations.sh
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/cnxdb/archive-sql/get-in-collated-book-search-full-page.sql
+++ b/cnxdb/archive-sql/get-in-collated-book-search-full-page.sql
@@ -45,6 +45,7 @@ WHERE
  cft.module_idx @@ plainto_tsquery(%(search_term)s) AND 
  m.uuid = (%(page_uuid)s) AND
  cft.context = book.module_ident AND
+ cfa.context = book.module_ident AND
  book.uuid = (%(uuid)s) AND
  module_version(book.major_version, book.minor_version) = %(version)s
 ORDER BY

--- a/cnxdb/archive-sql/get-module-latest-version.sql
+++ b/cnxdb/archive-sql/get-module-latest-version.sql
@@ -1,0 +1,12 @@
+-- ###
+-- Copyright (c) 2013, Rice University
+-- This software is subject to the provisions of the GNU Affero General
+-- Public License version 3 (AGPLv3).
+-- See LICENCE.txt for details.
+-- ###
+
+-- arguments: id:string
+SELECT
+module_version(m.major_version, m.minor_version)
+FROM latest_modules m
+WHERE m.uuid = %(id)s

--- a/cnxdb/archive-sql/schema/indexes.sql
+++ b/cnxdb/archive-sql/schema/indexes.sql
@@ -44,3 +44,14 @@ CREATE UNIQUE INDEX similarities_objectid_version_idx ON similarities (objectid,
 create index latest_modules_title_idx on latest_modules (upper(title_order(name)));
 
 CREATE INDEX modules_strip_html_name_trgm_gin ON modules USING gin(strip_html(name) gin_trgm_ops);
+
+
+-- These indexes are in support of deletion of things from modules, such as CompositeModules when rebaking
+CREATE INDEX collated_file_associations_context_fkey ON collated_file_associations (context);
+CREATE INDEX collated_file_associations_item_fkey ON collated_file_associations (item);
+CREATE INDEX collated_fti_context_fkey ON collated_fti (context);
+CREATE INDEX collated_fti_item_fkey ON collated_fti (item);
+CREATE INDEX collated_fti_lexemes_context_fkey ON collated_fti_lexemes (context);
+CREATE INDEX collated_fti_lexemes_item_fkey ON collated_fti_lexemes (item);
+CREATE INDEX document_hits_documentid_fkey ON document_hits (documentid);
+CREATE INDEX moduletags_module_ident_fkey ON moduletags (module_ident);

--- a/cnxdb/archive-sql/schema/legacy/indexes.sql
+++ b/cnxdb/archive-sql/schema/legacy/indexes.sql
@@ -2,3 +2,4 @@ CREATE INDEX person_firstname_upper_idx on persons (upper(firstname));
 CREATE INDEX person_surname_upper_idx on persons (upper(surname));
 CREATE INDEX person_personid_upper_idx on persons (upper(personid));
 CREATE INDEX person_email_upper_idx on persons (upper(email));
+CREATE INDEX moduleratings_module_ident_fkey ON moduleratings (module_ident);

--- a/cnxdb/archive-sql/schema/shred_collxml.py
+++ b/cnxdb/archive-sql/schema/shred_collxml.py
@@ -55,13 +55,13 @@ WHERE nodeid = %s"""
 SUBCOL_INS="""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', 'col'||nextval('collectionid_seq'), %s, uuid5(uuid, %s),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style
@@ -71,13 +71,13 @@ WHERE nodeid = %s RETURNING module_ident"""
 SUBCOL_NEW_VERSION="""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', %s, %s, uuid5(uuid, %s),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog, stateid,
+    licenseid, submitter, submitlog,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style

--- a/cnxdb/archive-sql/schema/tables.sql
+++ b/cnxdb/archive-sql/schema/tables.sql
@@ -185,13 +185,13 @@ CREATE TABLE "keywords" (
 CREATE TABLE "modulekeywords" (
 	"module_ident" integer NOT NULL,
 	"keywordid" integer NOT NULL,
-	FOREIGN KEY (module_ident) REFERENCES "modules" DEFERRABLE,
+	FOREIGN KEY (module_ident) REFERENCES modules (module_ident) ON DELETE CASCADE DEFERRABLE,
 	FOREIGN KEY (keywordid) REFERENCES "keywords" DEFERRABLE
 );
 
 CREATE TABLE module_files (
-    module_ident integer references modules,
-    fileid integer references files,
+    module_ident integer REFERENCES modules ON DELETE CASCADE,
+    fileid integer REFERENCES files,
     filename text
 );
 
@@ -214,7 +214,7 @@ CREATE TABLE tags (
 CREATE TABLE moduletags (
     module_ident integer,
     tagid integer,
-    FOREIGN KEY (module_ident) REFERENCES modules(module_ident) DEFERRABLE,
+    FOREIGN KEY (module_ident) REFERENCES modules (module_ident) ON DELETE CASCADE DEFERRABLE,
     FOREIGN KEY (tagid) REFERENCES tags(tagid) DEFERRABLE
 );
 
@@ -275,9 +275,9 @@ CREATE TABLE collated_file_associations (
   context INTEGER,
   item INTEGER,
   fileid INTEGER,
-  FOREIGN KEY (fileid) REFERENCES files (fileid),
-  FOREIGN KEY (context) REFERENCES modules (module_ident),
-  FOREIGN KEY (item) REFERENCES modules (module_ident),
+  FOREIGN KEY (fileid) REFERENCES files (fileid) ON DELETE CASCADE,
+  FOREIGN KEY (context) REFERENCES modules (module_ident) ON DELETE CASCADE,
+  FOREIGN KEY (item) REFERENCES modules (module_ident) on DELETE CASCADE,
   -- primary key allows for a single collection and module association
   PRIMARY KEY (context, item)
 );

--- a/cnxdb/migrations/20160723123620_add_sql_function_strip_html.py
+++ b/cnxdb/migrations/20160723123620_add_sql_function_strip_html.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from dbmigrator import super_user
+
 
 def up(cursor):
-    cursor.execute("""\
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
 CREATE OR REPLACE FUNCTION strip_html(html_text TEXT)
   RETURNS text
 AS $$
@@ -13,4 +16,5 @@ $$ LANGUAGE plpythonu IMMUTABLE;
 
 
 def down(cursor):
-    cursor.execute("DROP FUNCTION IF EXISTS strip_html(TEXT)")
+    with super_user() as super_cursor:
+        super_cursor.execute("DROP FUNCTION IF EXISTS strip_html(TEXT)")

--- a/cnxdb/migrations/20160723124137_add_modules_strip_html_name_index.py
+++ b/cnxdb/migrations/20160723124137_add_modules_strip_html_name_index.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from dbmigrator import super_user
+
 
 def up(cursor):
-    cursor.execute("""\
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
 CREATE EXTENSION pg_trgm;
 CREATE INDEX modules_strip_html_name_trgm_gin ON modules \
     USING gin(strip_html(name) gin_trgm_ops);
@@ -10,7 +13,8 @@ CREATE INDEX modules_strip_html_name_trgm_gin ON modules \
 
 
 def down(cursor):
-    cursor.execute("""\
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
 DROP INDEX IF EXISTS modules_strip_html_name_trgm_gin;
 DROP EXTENSION IF EXISTS pg_trgm;
 """)

--- a/cnxdb/migrations/20170201213850_add-subcollection-metadata.py
+++ b/cnxdb/migrations/20170201213850_add-subcollection-metadata.py
@@ -3,6 +3,8 @@ import os
 
 from contextlib import contextmanager
 
+from dbmigrator import super_user
+
 
 @contextmanager
 def open_here(filepath, *args, **kwargs):
@@ -17,12 +19,13 @@ def open_here(filepath, *args, **kwargs):
 def up(cursor):
     """Add subcol metadata support to shredding and data upgrades"""
 
-    cursor.execute("""
+    with super_user() as super_cursor:
+        super_cursor.execute("""
 CREATE FUNCTION uuid5(namespace uuid, name text) RETURNS uuid
     LANGUAGE plpythonu
     AS $_$ import uuid; return uuid.uuid5(uuid.UUID(namespace), name) $_$;""")
 
-    cursor.execute("""
+        super_cursor.execute("""
 CREATE OR REPLACE FUNCTION public.is_baked(col_uuid uuid, col_ver text)
  RETURNS boolean
  LANGUAGE sql
@@ -34,19 +37,19 @@ SELECT bool_or(is_collated)
           module_version(major_version, minor_version) = col_ver
 $function$;""")
 
-    with open_here('../archive-sql/schema/subcol_uuids_func.sql', 'rb') as f:
-        cursor.execute(f.read())
+        with open_here('../archive-sql/schema/subcol_uuids_func.sql',
+                       'rb') as f:
+            super_cursor.execute(f.read())
 
-    with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
-        cursor.execute(f.read())
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
 
 
 def down(cursor):
-    # TODO rollback code
+    with super_user() as super_cursor:
+        super_cursor.execute('drop function uuid5(uuid, text)')
+        super_cursor.execute('drop function is_baked(uuid, text)')
+        super_cursor.execute('drop function subcol_uuids(text, text)')
 
-    cursor.execute('drop function uuid5(uuid, text)')
-    cursor.execute('drop function is_baked(uuid, text)')
-    cursor.execute('drop function subcol_uuids(text, text)')
-
-    with open_here('shred_collxml_20170201213850_pre.sql', 'rb') as f:
-        cursor.execute(f.read())
+        with open_here('shred_collxml_20170201213850_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())

--- a/cnxdb/migrations/20170208213802_ident-hash-func.py
+++ b/cnxdb/migrations/20170208213802_ident-hash-func.py
@@ -3,6 +3,8 @@ import os
 
 from contextlib import contextmanager
 
+from dbmigrator import super_user
+
 
 @contextmanager
 def open_here(filepath, *args, **kwargs):
@@ -15,9 +17,9 @@ def open_here(filepath, *args, **kwargs):
 
 
 def up(cursor):
-
-    with open_here('../archive-sql/schema/functions.sql', 'rb') as f:
-        cursor.execute(f.read())
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/functions.sql', 'rb') as f:
+            super_cursor.execute(f.read())
 
     cursor.execute("""
 CREATE INDEX modules_ident_hash on modules(ident_hash(uuid, major_version, minor_version));
@@ -25,7 +27,8 @@ CREATE INDEX modules_short_ident_hash on modules(short_ident_hash(uuid, major_ve
 
 
 def down(cursor):
-    # TODO rollback code
-
-    cursor.execute('drop function ident_hash(uuid, int, int) CASCADE')
-    cursor.execute('drop function short_ident_hash(uuid, int, int) CASCADE')
+    with super_user() as super_cursor:
+        super_cursor.execute(
+            'drop function ident_hash(uuid, int, int) CASCADE')
+        super_cursor.execute(
+            'drop function short_ident_hash(uuid, int, int) CASCADE')

--- a/cnxdb/migrations/20170815141631_subcol-uuids-fn.py
+++ b/cnxdb/migrations/20170815141631_subcol-uuids-fn.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 
 
+from dbmigrator import super_user
+
+
 # Uncomment should_run if this is a repeat migration
 # def should_run(cursor):
 #     # TODO return True if migration should run
 
 
 def up(cursor):
-    # TODO migration code
-
-    cursor.execute('''
+    with super_user() as super_cursor:
+        super_cursor.execute('''
 CREATE OR REPLACE FUNCTION subcol_uuids(uuid uuid, version text) RETURNS VOID
  LANGUAGE sql
 AS $function$
@@ -126,7 +128,8 @@ $function$
 
 def down(cursor):
     # rollback to broken function def
-    cursor.execute('''
+    with super_user() as super_cursor:
+        super_cursor.execute('''
 CREATE OR REPLACE FUNCTION subcol_uuids(uuid uuid, version text)
  RETURNS void
  LANGUAGE sql

--- a/cnxdb/migrations/20170816204849_subcol-uuid-data.py
+++ b/cnxdb/migrations/20170816204849_subcol-uuid-data.py
@@ -30,16 +30,9 @@ def up(cursor):
 
     num_todo = len(anon_subcols)
     logger.info('Books to add chapter uuids: {}'.format(num_todo))
-
-    if num_todo > 10:
-        batch_size = int(num_todo / 10)
-    else:
-        batch_size = num_todo
-
-    if batch_size > 10:
-        batch_size = 10
-
+    batch_size = 10
     logger.info('Batch size: {}'.format(batch_size))
+
     start = time.time()
     guesstimate = 7 * num_todo
     guess_complete = guesstimate + start
@@ -47,6 +40,7 @@ def up(cursor):
                 '"{}" ({})'.format(time.ctime(guess_complete),
                                    timedelta(0, guesstimate)))
     num_complete = 0
+    elapsed = 0
     for batch in _batcher(anon_subcols, batch_size):
         for book in batch:
             cursor.execute("SELECT subcol_uuids(%s, %s)", book)

--- a/cnxdb/migrations/20170911200000_update_index_cnxml.py
+++ b/cnxdb/migrations/20170911200000_update_index_cnxml.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    # Select all the modules that have both index.cnxml and
+    # index_auto_generated.cnxml
+    cursor.execute("""\
+SELECT module_ident, array_agg(fileid),
+       array_agg(substring(
+           encode(file, 'escape') from 'cnxml-version=.....'))
+    FROM module_files NATURAL JOIN files
+    WHERE filename IN ('index.cnxml', 'index_auto_generated.cnxml')
+    GROUP BY module_ident HAVING count(*) > 1""")
+    rows = cursor.fetchall()
+
+    if not rows:
+        # nothing to do
+        return
+
+    # Create table for rollback
+    module_idents = [r[0] for r in rows]
+    cursor.execute("""\
+CREATE TABLE datamigrations.index_auto_generated AS
+    SELECT * FROM module_files
+        WHERE module_ident IN %s
+          AND filename IN ('index.cnxml', 'index_auto_generated.cnxml')
+""", (tuple(module_idents),))
+
+    for row in rows:
+        module_ident, fileids, cnxml_versions = row
+        if cnxml_versions == [None, None]:
+            # Skip files that have no cnxml version
+            continue
+        elif cnxml_versions[0] is None:
+            keep_fileid = fileids[1]
+        elif cnxml_versions[1] is None:
+            keep_fileid = fileids[0]
+        else:
+            # Choose the higher fileid if the cnxml versions are the same
+            if cmp(*cnxml_versions) == 0:
+                keep_fileid = max(fileids)
+            elif cmp(*cnxml_versions) == 1:
+                keep_fileid = fileids[0]
+            else:
+                keep_fileid = fileids[1]
+
+        cursor.execute("""\
+UPDATE module_files SET fileid = %s
+    WHERE filename = 'index.cnxml' AND module_ident = %s""",
+                       (keep_fileid, module_ident))
+        cursor.execute("""\
+DELETE FROM module_files
+    WHERE filename = 'index_auto_generated.cnxml'
+      AND module_ident = %s""", (module_ident,))
+
+
+def down(cursor):
+    cursor.execute("""\
+SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'index_auto_generated'
+      AND table_schema = 'datamigrations'""")
+    if not cursor.fetchall():
+        # nothing to rollback
+        return
+    cursor.execute("""\
+UPDATE module_files
+    SET fileid = b.fileid
+    FROM datamigrations.index_auto_generated b
+    WHERE module_files.module_ident = b.module_ident
+      AND module_files.fileid != b.fileid
+      AND module_files.filename = 'index.cnxml';
+INSERT INTO module_files
+    SELECT * FROM datamigrations.index_auto_generated b
+        WHERE b.filename = 'index_auto_generated.cnxml'
+          AND NOT EXISTS
+            (SELECT 1
+                FROM module_files
+                WHERE module_ident = b.module_ident
+                  AND filename = 'index_auto_generated.cnxml');
+DROP TABLE datamigrations.index_auto_generated""")

--- a/cnxdb/migrations/20170911201035_transform_cnxml_to_html.py
+++ b/cnxdb/migrations/20170911201035_transform_cnxml_to_html.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+import time
+from datetime import timedelta
+
+import rhaptos.cnxmlutils
+from dbmigrator import deferred, logger
+
+
+def _batcher(seq, size):
+    for pos in range(0, len(seq), size):
+        yield seq[pos:pos + size]
+
+
+def should_run(cursor, limit='LIMIT 1'):
+    version = rhaptos.cnxmlutils.__version__
+    version_text = '%data-cnxml-to-html-ver="{}"%'.format(version)
+    logger.info('Looking for {}'.format(version_text))
+    cursor.execute("""\
+WITH index_cnxml_html AS (
+    SELECT files.fileid, module_ident, file
+        FROM module_files NATURAL JOIN files
+        WHERE filename = 'index.cnxml.html'
+) SELECT fileid, max(module_ident)
+    FROM index_cnxml_html
+    WHERE convert_from(file, 'utf-8') NOT LIKE %s
+    GROUP BY fileid {}""".format(limit),
+                   (version_text,))
+    return cursor.fetchall()
+
+
+@deferred
+def up(cursor):
+    """Transform all index.cnxml to index.cnxml.html"""
+    # Get all the index.cnxml.html that does not have rhaptos.cnxmlutils
+    # current version
+    to_transform = should_run(cursor, limit='')
+    num_todo = len(to_transform)
+
+    batch_size = 100
+    logger.info('Pages to transform: {}'.format(num_todo))
+    logger.info('Batch size: {}'.format(batch_size))
+
+    start = time.time()
+    guesstimate = 0.01 * num_todo
+    guess_complete = guesstimate + start
+    logger.info('Completion guess: '
+                '"{}" ({})'.format(time.ctime(guess_complete),
+                                   timedelta(0, guesstimate)))
+    module_idents = tuple([i[1] for i in to_transform])
+
+    # Check if datamigrations.index_cnxml_html exists, else create it
+    cursor.execute("""\
+CREATE TABLE IF NOT EXISTS datamigrations.index_cnxml_html
+    ( LIKE module_files )""")
+    # Store module_files for modules we are going to update
+    cursor.execute("""\
+INSERT INTO datamigrations.index_cnxml_html
+    SELECT * FROM module_files
+        WHERE module_ident IN %s
+          AND filename = 'index.cnxml.html'
+          AND NOT EXISTS (
+            SELECT 1 FROM datamigrations.index_cnxml_html b
+                WHERE b.module_ident = module_files.module_ident);
+UPDATE datamigrations.index_cnxml_html b
+    SET fileid = module_files.fileid
+    FROM module_files
+    WHERE module_files.module_ident = b.module_ident
+      AND module_files.filename = b.filename
+      AND module_files.fileid != b.fileid
+      AND module_files.module_ident IN %s""",
+                   (module_idents, module_idents))
+
+    num_complete = 0
+    for batch in _batcher(to_transform, batch_size):
+        module_idents = tuple([i[1] for i in batch])
+        logger.debug('Transform module_idents {}'.format(module_idents))
+
+        for fileid, module_ident in batch:
+            cursor.execute("""\
+WITH index_cnxml AS (
+    SELECT files.fileid, file
+        FROM module_files NATURAL JOIN files
+        WHERE module_ident = %(module_ident)s
+          AND filename = 'index.cnxml'
+        LIMIT 1
+), transformed AS (
+    SELECT html_content(%(module_ident)s) AS content
+) INSERT INTO files
+    (file, media_type)
+    SELECT convert_to(transformed.content, 'utf-8'), 'text/xml'
+        FROM index_cnxml, transformed
+        WHERE char_length(substring(encode(file, 'escape')
+                                    FROM 'cnxml-version=.0.7.')) > 0
+          AND NOT EXISTS (
+            SELECT 1 FROM files
+                WHERE sha1 = sha1(transformed.content))
+RETURNING fileid""", {'module_ident': module_ident})
+            new_fileid = cursor.fetchall()
+            if new_fileid:
+                cursor.execute("""\
+UPDATE module_files SET fileid = %s
+WHERE fileid = %s""", (new_fileid[0][0], fileid))
+
+        cursor.connection.commit()
+        num_complete += len(batch)
+        percent_comp = num_complete * 100.0 / num_todo
+        elapsed = time.time() - start
+        remaining_est = elapsed * (num_todo - num_complete) / num_complete
+        est_complete = start + elapsed + remaining_est
+        logger.info('{:.1f}% complete '
+                    'est: "{}" ({})'.format(percent_comp,
+                                            time.ctime(est_complete),
+                                            timedelta(0, remaining_est)))
+
+    logger.info('Total runtime: {}'.format(timedelta(0, elapsed)))
+
+
+def down(cursor):
+    # Restore module_files save in datamigrations.index_cnxml_html
+    cursor.execute("""\
+WITH to_delete AS (
+    SELECT module_ident, fileid FROM module_files
+    WHERE NOT EXISTS (
+        SELECT 1 FROM datamigrations.index_cnxml_html b WHERE
+            b.fileid = module_files.fileid)
+      AND EXISTS (
+        SELECT 1 FROM datamigrations.index_cnxml_html b WHERE
+            b.module_ident = module_files.module_ident)
+      AND filename = 'index.cnxml.html'
+), update AS (
+UPDATE module_files
+    SET fileid = b.fileid
+    FROM datamigrations.index_cnxml_html b
+    WHERE module_files.module_ident = b.module_ident
+      AND module_files.fileid != b.fileid
+      AND module_files.filename = 'index.cnxml.html'
+)
+DELETE FROM files
+    WHERE EXISTS (
+        SELECT 1 FROM to_delete
+        WHERE to_delete.fileid = files.fileid)
+        AND NOT EXISTS (
+            SELECT 1 FROM module_files
+            WHERE module_files.fileid = files.fileid);
+DROP TABLE datamigrations.index_cnxml_html""")

--- a/cnxdb/migrations/20170912134157_shred-colxml-uuids.py
+++ b/cnxdb/migrations/20170912134157_shred-colxml-uuids.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-
 from contextlib import contextmanager
+
+from dbmigrator import super_user
 
 
 @contextmanager
@@ -15,16 +16,17 @@ def open_here(filepath, *args, **kwargs):
 
 
 def up(cursor):
-
-    with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
-        cursor.execute(f.read())
-    cursor.execute('drop function shred_collxml(text)')
-    cursor.execute('drop function shred_collxml(int)')
-    cursor.execute('drop function shred_collxml(int,int)')
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+        super_cursor.execute('drop function shred_collxml(text)')
+        super_cursor.execute('drop function shred_collxml(int)')
+        super_cursor.execute('drop function shred_collxml(int,int)')
 
 
 def down(cursor):
-    with open_here('shred_collxml_20170912134157_pre.sql', 'rb') as f:
-        cursor.execute(f.read())
-    cursor.execute('drop function shred_collxml(text, integer)')
-    cursor.execute('drop function shred_collxml(integer, integer, bool)')
+    with super_user() as super_cursor:
+        with open_here('shred_collxml_20170912134157_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+        super_cursor.execute('drop function shred_collxml(text, integer)')
+        super_cursor.execute('drop function shred_collxml(integer, integer, bool)')

--- a/cnxdb/migrations/20170912184444_foreign-key-idx.py
+++ b/cnxdb/migrations/20170912184444_foreign-key-idx.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+        ALTER TABLE modulekeywords DROP CONSTRAINT
+        modulekeywords_module_ident_fkey;
+
+        ALTER TABLE modulekeywords ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+        ON DELETE CASCADE DEFERRABLE""")
+
+    cursor.execute("""
+        ALTER TABLE moduletags DROP CONSTRAINT
+        moduletags_module_ident_fkey;
+
+        ALTER TABLE moduletags ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+        ON DELETE CASCADE DEFERRABLE""")
+
+    cursor.execute("""
+        ALTER TABLE module_files DROP CONSTRAINT
+        module_files_module_ident_fkey;
+
+        ALTER TABLE module_files ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+        ON DELETE CASCADE""")
+
+    cursor.execute("""
+        ALTER TABLE collated_file_associations DROP CONSTRAINT
+        collated_file_associations_context_fkey;
+
+        ALTER TABLE collated_file_associations ADD FOREIGN KEY
+        (context) REFERENCES modules(module_ident)
+        ON DELETE CASCADE;
+
+        ALTER TABLE collated_file_associations DROP CONSTRAINT
+        collated_file_associations_item_fkey;
+
+        ALTER TABLE collated_file_associations ADD FOREIGN KEY
+        (item) REFERENCES modules(module_ident)
+        ON DELETE CASCADE;
+
+        ALTER TABLE collated_file_associations DROP CONSTRAINT
+        collated_file_associations_fileid_fkey;
+
+        ALTER TABLE collated_file_associations ADD FOREIGN KEY
+        (fileid) REFERENCES files(fileid)
+        ON DELETE CASCADE""")
+
+    cursor.execute("""
+        ALTER TABLE document_baking_result_associations DROP CONSTRAINT
+        document_baking_result_associations_module_ident_fkey;
+
+        ALTER TABLE document_baking_result_associations ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+        ON DELETE CASCADE""")
+
+    # Need to close transaction to allow concurrent index creation
+    cursor.execute('COMMIT')
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY
+            collated_file_associations_context_fkey
+                ON collated_file_associations (context);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY
+            collated_file_associations_item_fkey
+                ON collated_file_associations (item);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY collated_fti_context_fkey
+            ON collated_fti (context);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY collated_fti_item_fkey
+            ON collated_fti (item);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY
+            collated_fti_lexemes_context_fkey
+                ON collated_fti_lexemes (context);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY collated_fti_lexemes_item_fkey
+            ON collated_fti_lexemes (item);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY
+            document_baking_result_associations_module_ident_fkey
+                ON document_baking_result_associations (module_ident);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY document_hits_documentid_fkey
+            ON document_hits (documentid);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY moduleratings_module_ident_fkey
+            ON moduleratings (module_ident);
+    """)
+    cursor.execute("""
+        CREATE INDEX CONCURRENTLY moduletags_module_ident_fkey
+            ON moduletags (module_ident);
+    """)
+
+
+def down(cursor):
+    # Need to close transaction to allow concurrent index deletion
+    cursor.execute('COMMIT')
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY
+            collated_file_associations_context_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY
+            collated_file_associations_item_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY collated_fti_context_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY collated_fti_item_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY
+            collated_fti_lexemes_context_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY collated_fti_lexemes_item_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY
+            document_baking_result_associations_module_ident_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY document_hits_documentid_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY moduleratings_module_ident_fkey;
+    """)
+    cursor.execute("""
+        DROP INDEX CONCURRENTLY moduletags_module_ident_fkey;
+    """)
+
+    cursor.execute("""
+        ALTER TABLE modulekeywords DROP CONSTRAINT
+        modulekeywords_module_ident_fkey;
+
+        ALTER TABLE modulekeywords ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+         DEFERRABLE""")
+
+    cursor.execute("""
+        ALTER TABLE moduletags DROP CONSTRAINT
+        moduletags_module_ident_fkey;
+
+        ALTER TABLE moduletags ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+         DEFERRABLE""")
+
+    cursor.execute("""
+        ALTER TABLE module_files DROP CONSTRAINT
+        module_files_module_ident_fkey;
+
+        ALTER TABLE module_files ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+        """)
+
+    cursor.execute("""
+        ALTER TABLE collated_file_associations DROP CONSTRAINT
+        collated_file_associations_context_fkey;
+
+        ALTER TABLE collated_file_associations ADD FOREIGN KEY
+        (context) REFERENCES modules(module_ident);
+
+        ALTER TABLE collated_file_associations DROP CONSTRAINT
+        collated_file_associations_item_fkey;
+
+        ALTER TABLE collated_file_associations ADD FOREIGN KEY
+        (item) REFERENCES modules(module_ident);
+
+        ALTER TABLE collated_file_associations DROP CONSTRAINT
+        collated_file_associations_fileid_fkey;
+
+        ALTER TABLE collated_file_associations ADD FOREIGN KEY
+        (fileid) REFERENCES files(fileid)
+        """)
+
+    cursor.execute("""
+        ALTER TABLE document_baking_result_associations DROP CONSTRAINT
+        document_baking_result_associations_module_ident_fkey;
+
+        ALTER TABLE document_baking_result_associations ADD FOREIGN KEY
+        (module_ident) REFERENCES modules(module_ident)
+        """)

--- a/cnxdb/migrations/20170918181635_rebake-double-trigger.py
+++ b/cnxdb/migrations/20170918181635_rebake-double-trigger.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION rebake()
+     RETURNS trigger
+     LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      UPDATE modules SET stateid = 5
+        WHERE module_ident = NEW.module_ident and stateid not in (5, 6);
+      RETURN NEW;
+    END;
+    $$;
+    """)
+
+
+def down(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION rebake()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        UPDATE modules SET stateid = 5
+          WHERE module_ident = NEW.module_ident;
+        RETURN NEW;
+      END;
+    $$
+    """)

--- a/cnxdb/migrations/20170922150407_shred-collxml-stateid.py
+++ b/cnxdb/migrations/20170922150407_shred-collxml-stateid.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import os
+from contextlib import contextmanager
+
+from dbmigrator import super_user
+
+
+@contextmanager
+def open_here(filepath, *args, **kwargs):
+    """open a file relative to this files location"""
+
+    here = os.path.abspath(os.path.dirname(__file__))
+    fp = open(os.path.join(here, filepath), *args, **kwargs)
+    yield fp
+    fp.close()
+
+
+def up(cursor):
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+
+
+def down(cursor):
+    with super_user() as super_cursor:
+        with open_here('shred_collxml_20170922150407_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())

--- a/cnxdb/migrations/shred_collxml_20170922150407_pre.sql
+++ b/cnxdb/migrations/shred_collxml_20170922150407_pre.sql
@@ -67,13 +67,13 @@ WHERE nodeid = $2""", ("text","int"))
 SUBCOL_INS=plpy.prepare("""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', 'col'||nextval('collectionid_seq'), $1, uuid5(uuid, $1),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style
@@ -83,13 +83,13 @@ WHERE nodeid = $2  RETURNING module_ident""", ("text","int"))
 SUBCOL_NEW_VERSION=plpy.prepare("""
 INSERT into modules (portal_type, moduleid, name, uuid,
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style)
 SELECT 'SubCollection', $3, $1, uuid5(uuid, $1),
     abstractid, version, created, revised,
-    licenseid, submitter, submitlog,
+    licenseid, submitter, submitlog, stateid,
     parent, language, doctype,
     authors, maintainers, licensors, parentauthors,
     major_version, minor_version, print_style

--- a/cnxdb/publishing-sql/schema-indexes.sql
+++ b/cnxdb/publishing-sql/schema-indexes.sql
@@ -8,3 +8,4 @@
 
 CREATE INDEX "pending_resources_hash_idx" on "pending_resources" ("hash");
 CREATE INDEX "pending_documents_ident_hash" on pending_documents (ident_hash(uuid, major_version, minor_version));
+CREATE INDEX document_baking_result_associations_module_ident_fkey ON document_baking_result_associations (module_ident);

--- a/cnxdb/publishing-sql/schema-tables.sql
+++ b/cnxdb/publishing-sql/schema-tables.sql
@@ -119,5 +119,5 @@ CREATE TABLE document_baking_result_associations (
   "result_id" UUID NOT NULL,
   "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY ("module_ident", "result_id"),
-  FOREIGN KEY ("module_ident") REFERENCES modules ("module_ident")
+  FOREIGN KEY ("module_ident") REFERENCES modules ("module_ident") ON DELETE CASCADE
 );

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,13 @@
 
    - feature message
 
+0.10.1
+------
+
+- Fix in-collated-book page search sql query (#68)
+- Add a matching migration for the double-trigger-when-rebaking fix (#69)
+- Fix derived_book_ruleset sql function by returning a value (#67 #66)
+
 0.10.0
 ------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,12 @@
 
    - feature message
 
+0.10.3
+------
+
+- Fix to ignore stateid when copying subcollections to avoid adding
+  subcollections to the post-publication queue (#73)
+
 0.10.2
 ------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,19 @@
 
    - feature message
 
+0.10.0
+------
+
+- Add query to get latest version of the content (#64)
+- Use super user to replace plpythonu function in migration (#62)
+- Add migration to transform cnxml->html (#59)
+- Add delete cascade and indexes for foreign keys (#58)
+- Add data migration to update index.cnxml (#61)
+- Add trigger for duplicating rulset.css for derived copies (#56)
+- Add subcollection uuid data migration (#54)
+- Fix minor versions and current_modules view (#49)
+- Add xpath queries (#40)
+
 0.9.0
 -----
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,12 @@
 
    - feature message
 
+0.10.2
+------
+
+- Use postgres super user in migrations that require it (#71)
+- Correct errors in subcol uuid migration associated with an empty batch (#70)
+
 0.10.1
 ------
 


### PR DESCRIPTION
For AW 1.0 - (w/o print_style recipes) we are going to be storing the recipes directly in legacy. Therefore, this trigger is not needed, and in fact is causing a collision.

Note that this will _not_ pass the `ci_test_migrations` script, since I did a rebase to remove the two commits that introduced this trigger, rather than adding reversion code at the tip.