### PR TITLE
Book fulltext search

### DIFF
--- a/cnxdb/archive-sql/schema/fulltext-indexing.sql
+++ b/cnxdb/archive-sql/schema/fulltext-indexing.sql
@@ -37,18 +37,22 @@ CREATE OR REPLACE FUNCTION xml_to_baretext(xml) RETURNS text AS $$
 </xsl:stylesheet>
 $$ LANGUAGE xslt;
 
-CREATE OR REPLACE FUNCTION count_lexemes (myident int, mysearch text) RETURNS bigint as $$
-     select sum(array_length(positions,1))
-            from modulefti_lexemes,
-                 regexp_split_to_table(strip(to_tsvector(mysearch))::text,' ') s
-            where module_ident = myident and lexeme = substr(s,2,length(s)-2)
-$$ LANGUAGE SQL STABLE;
+CREATE OR REPLACE FUNCTION count_lexemes(myident integer, mysearch text)
+ RETURNS bigint
+ LANGUAGE sql
+ STABLE
+AS $function$
+WITH lexemes AS (SELECT word, nentry FROM ts_stat('SELECT module_idx FROM modulefti WHERE module_ident = ' || myident)),
+     words AS (select regexp_split_to_table(mysearch,' ') AS qwords)
+    SELECT SUM(nentry)::bigint FROM lexemes, words WHERE word @@ plainto_tsquery(qwords);
+    $function$;
 
-CREATE OR REPLACE FUNCTION count_collated_lexemes (myident int, bookident int, mysearch text) RETURNS bigint as $$
-     select sum(array_length(positions,1))
-            from collated_fti_lexemes,
-                 regexp_split_to_table(strip(to_tsvector(mysearch))::text,' ') s
-            where item = myident and context = bookident and lexeme = substr(s,2,length(s)-2)
+
+CREATE OR REPLACE FUNCTION count_collated_lexemes (myident int, bookident int, mysearch text) RETURNS bigint
+AS $$
+WITH lexemes AS (SELECT word, nentry FROM ts_stat('SELECT module_idx FROM collated_fti WHERE item = ' || myident || ' and context = ' || bookident)),
+     words AS (select regexp_split_to_table(mysearch,' ') AS qwords)
+    SELECT SUM(nentry)::bigint FROM lexemes, words WHERE word @@ plainto_tsquery(qwords);
 $$ LANGUAGE SQL STABLE;
 
 CREATE OR REPLACE FUNCTION index_fulltext_trigger()
@@ -109,29 +113,6 @@ CREATE TRIGGER index_fulltext_upsert
     FOR EACH row
       EXECUTE PROCEDURE index_fulltext_upsert_trigger();
 
-CREATE OR REPLACE FUNCTION index_fulltext_lexeme_update_trigger()
-  RETURNS TRIGGER AS $$
-  BEGIN
-
-    DELETE from modulefti_lexemes where module_ident = NEW.module_ident;
-
-    INSERT into modulefti_lexemes (module_ident, lexeme, positions)
-       (with lex as (SELECT regexp_split_to_table(NEW.module_idx::text, E' \'') as t )
-       SELECT NEW.module_ident,
-              substring(t,1,strpos(t,E'\':')-1),
-              ('{'||substring(t,strpos(t,E'\':')+2)||'}')::int[] from lex) ;
-
-  RETURN NEW;
-  END;
-  $$
-  LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS index_fulltext_lexeme ON modulefti;
-CREATE TRIGGER index_fulltext_lexeme
-  BEFORE INSERT OR UPDATE ON modulefti
-    FOR EACH row
-      EXECUTE PROCEDURE index_fulltext_lexeme_update_trigger();
-
 CREATE OR REPLACE FUNCTION index_collated_fulltext_trigger()
   RETURNS TRIGGER AS $$
   DECLARE
@@ -160,26 +141,3 @@ CREATE TRIGGER index_collated_fulltext
   AFTER INSERT OR UPDATE ON collated_file_associations
     FOR EACH row 
       EXECUTE PROCEDURE index_collated_fulltext_trigger();
-
-CREATE OR REPLACE FUNCTION index_collated_fulltext_lexeme_update_trigger()
-  RETURNS TRIGGER AS $$
-  BEGIN
-
-    DELETE from collated_fti_lexemes where item = NEW.item AND context = NEW.context;
-
-    INSERT into collated_fti_lexemes (item, context, lexeme, positions)
-       (with lex as (SELECT regexp_split_to_table(NEW.module_idx::text, E' \'') as t )
-       SELECT NEW.item, NEW.context,
-              substring(t,1,strpos(t,E'\':')-1),
-              ('{'||substring(t,strpos(t,E'\':')+2)||'}')::int[] from lex) ;
-
-  RETURN NEW;
-  END;
-  $$
-  LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS index_collated_fulltext_lexeme ON collated_fti;
-CREATE TRIGGER index_collated_fulltext_lexeme
-  BEFORE INSERT OR UPDATE ON collated_fti
-    FOR EACH row
-      EXECUTE PROCEDURE index_collated_fulltext_lexeme_update_trigger();

--- a/cnxdb/archive-sql/schema/fulltext-indexing.sql
+++ b/cnxdb/archive-sql/schema/fulltext-indexing.sql
@@ -139,5 +139,49 @@ CREATE OR REPLACE FUNCTION index_collated_fulltext_trigger()
 DROP TRIGGER IF EXISTS index_collated_fulltext ON collated_file_associations;
 CREATE TRIGGER index_collated_fulltext
   AFTER INSERT OR UPDATE ON collated_file_associations
-    FOR EACH row 
+    FOR EACH row
       EXECUTE PROCEDURE index_collated_fulltext_trigger();
+
+CREATE AGGREGATE tsvector_agg (
+      BASETYPE = tsvector,
+      SFUNC = tsvector_concat,
+      STYPE = tsvector,
+      INITCOND = ''
+    );
+
+CREATE OR REPLACE FUNCTION insert_book_fti(bookid integer)
+  RETURNS void
+  LANGUAGE sql
+    AS $function$
+    WITH RECURSIVE t(node, parent, document, path) AS (
+        SELECT tr.nodeid, tr.parent_id, tr.documentid, ARRAY[tr.nodeid]
+        FROM trees tr
+        WHERE tr.documentid = bookid and tr.is_collated = 'False'
+      UNION ALL
+        SELECT c.nodeid, c.parent_id, c.documentid, path || ARRAY[c.nodeid]
+        FROM trees c JOIN t ON c.parent_id = t.node
+        WHERE NOT c.nodeid = ANY(t.path)
+      )
+    INSERT INTO modulefti (module_ident, module_idx)
+      SELECT bookid, tsvector_agg(mf.module_idx)
+        FROM t JOIN modulefti mf
+          ON t.document = mf.module_ident JOIN modules m
+          ON t.document = m.module_ident
+        WHERE m.portal_type IN ('Module','CompositeModule')
+    $function$;
+
+CREATE OR REPLACE FUNCTION index_fulltext_book_trigger()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    DELETE from modulefti WHERE module_ident = NEW.module_ident;
+    PERFORM insert_book_fti(NEW.module_ident);
+    RETURN NULL;
+  END;
+  $$
+  LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS index_fullext_book ON latest_modules;
+CREATE TRIGGER index_fulltext_book
+  AFTER INSERT OR UPDATE ON latest_modules
+    FOR EACH row WHEN (NEW.portal_type = 'Collection')
+      EXECUTE PROCEDURE index_fulltext_book_trigger();

--- a/cnxdb/archive-sql/schema/functions.sql
+++ b/cnxdb/archive-sql/schema/functions.sql
@@ -4,6 +4,23 @@ CREATE OR REPLACE FUNCTION "comma_cat" (text,text) RETURNS text AS 'select case 
 
 CREATE OR REPLACE FUNCTION "semicomma_cat" (text,text) RETURNS text AS 'select case WHEN $2 is NULL or $2 = '''' THEN $1 WHEN $1 is NULL or $1 = '''' THEN $2 ELSE $1 || '';--;'' || $2 END' LANGUAGE 'sql';
 
+CREATE OR REPLACE FUNCTION sha1(file text)
+ RETURNS text
+ LANGUAGE plpythonu
+ IMMUTABLE STRICT
+AS $function$
+import hashlib
+return hashlib.new('sha1', file).hexdigest()
+$function$;
+
+CREATE OR REPLACE FUNCTION sha1(f bytea)
+ RETURNS text
+ LANGUAGE plpythonu
+AS $function$
+import hashlib
+return hashlib.new('sha1',f).hexdigest()
+$function$;
+
 CREATE OR REPLACE FUNCTION title_order(text) RETURNS text AS $$
 begin
 if lower(substr($1, 1, 4)) = 'the ' then

--- a/cnxdb/archive-sql/schema/indexes.sql
+++ b/cnxdb/archive-sql/schema/indexes.sql
@@ -22,8 +22,6 @@ CREATE UNIQUE INDEX lastest_modules_short_id_idx on latest_modules (short_id(uui
 CREATE INDEX fti_idx ON modulefti USING gist (module_idx);
 CREATE INDEX collated_fti_idx ON collated_fti USING gist (module_idx);
 
-CREATE INDEX modulefti_lexemes_module_ident on modulefti_lexemes (module_ident);
-CREATE INDEX collated_fti_lexemes_context_item_idx on collated_fti_lexemes (context, item);
 CREATE INDEX moduletags_module_ident_idx on moduletags (module_ident);
 
 CREATE INDEX keywords_upword_idx ON keywords  (upper(word));
@@ -51,7 +49,5 @@ CREATE INDEX collated_file_associations_context_fkey ON collated_file_associatio
 CREATE INDEX collated_file_associations_item_fkey ON collated_file_associations (item);
 CREATE INDEX collated_fti_context_fkey ON collated_fti (context);
 CREATE INDEX collated_fti_item_fkey ON collated_fti (item);
-CREATE INDEX collated_fti_lexemes_context_fkey ON collated_fti_lexemes (context);
-CREATE INDEX collated_fti_lexemes_item_fkey ON collated_fti_lexemes (item);
 CREATE INDEX document_hits_documentid_fkey ON document_hits (documentid);
 CREATE INDEX moduletags_module_ident_fkey ON moduletags (module_ident);

--- a/cnxdb/archive-sql/schema/tables.sql
+++ b/cnxdb/archive-sql/schema/tables.sql
@@ -151,28 +151,12 @@ CREATE TABLE "modulefti" (
 	FOREIGN KEY (module_ident) REFERENCES modules ON DELETE CASCADE
 );
 
-CREATE TABLE "modulefti_lexemes" (
-	"module_ident" integer,
-	"lexeme" text,
-    "positions" int[],
-	FOREIGN KEY (module_ident) REFERENCES modules ON DELETE CASCADE
-);
-
 CREATE TABLE "collated_fti" (
 	"item" integer,
 	"context" integer,
 	"module_idx" tsvector,
     "fulltext" text,
     PRIMARY KEY ("item", "context"),
-	FOREIGN KEY (item) REFERENCES modules (module_ident) ON DELETE CASCADE,
-	FOREIGN KEY (context) REFERENCES modules (module_ident) ON DELETE CASCADE
-);
-
-CREATE TABLE "collated_fti_lexemes" (
-	"item" integer,
-	"context" integer,
-	"lexeme" text,
-    "positions" int[],
 	FOREIGN KEY (item) REFERENCES modules (module_ident) ON DELETE CASCADE,
 	FOREIGN KEY (context) REFERENCES modules (module_ident) ON DELETE CASCADE
 );

--- a/cnxdb/migrations/20170911201035_transform_cnxml_to_html.py
+++ b/cnxdb/migrations/20170911201035_transform_cnxml_to_html.py
@@ -49,6 +49,7 @@ def up(cursor):
     module_idents = tuple([i[1] for i in to_transform])
 
     # Check if datamigrations.index_cnxml_html exists, else create it
+    cursor.execute("CREATE SCHEMA IF NOT EXISTS datamigrations")
     cursor.execute("""\
 CREATE TABLE IF NOT EXISTS datamigrations.index_cnxml_html
     ( LIKE module_files )""")

--- a/cnxdb/migrations/20170926023421_remove-lexeme-tables.py
+++ b/cnxdb/migrations/20170926023421_remove-lexeme-tables.py
@@ -69,7 +69,6 @@ CREATE OR REPLACE FUNCTION count_collated_lexemes(myident integer, bookident int
             where item = myident and context = bookident and lexeme = substr(s,2,length(s)-2)
 $_$;
 
-ALTER FUNCTION count_collated_lexemes(myident integer, bookident integer, mysearch text) OWNER TO reedstrm;
 
 CREATE OR REPLACE FUNCTION count_lexemes(myident integer, mysearch text) RETURNS bigint
     LANGUAGE sql STABLE

--- a/cnxdb/migrations/20170926023421_remove-lexeme-tables.py
+++ b/cnxdb/migrations/20170926023421_remove-lexeme-tables.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION count_collated_lexemes(myident integer, bookident integer, mysearch text) RETURNS bigint
+        LANGUAGE sql STABLE
+        AS $_$
+    WITH lexemes AS (SELECT word, nentry FROM ts_stat('SELECT module_idx FROM collated_fti WHERE item = ' || myident || ' and context = ' || bookident)),
+         words AS (select regexp_split_to_table(mysearch,' ') AS qwords)
+        SELECT SUM(nentry)::bigint FROM lexemes, words WHERE word @@ plainto_tsquery(qwords);
+        $_$;
+
+    CREATE OR REPLACE FUNCTION count_lexemes(myident integer, mysearch text) RETURNS bigint
+        LANGUAGE sql STABLE
+        AS $_$
+    WITH lexemes AS (SELECT word, nentry FROM ts_stat('SELECT module_idx FROM modulefti WHERE module_ident = ' || myident)),
+         words AS (select regexp_split_to_table(mysearch,' ') AS qwords)
+        SELECT SUM(nentry)::bigint FROM lexemes, words WHERE word @@ plainto_tsquery(qwords);
+        $_$;
+
+    ALTER TABLE modulefti_lexemes DROP CONSTRAINT modulefti_lexemes_module_ident_fkey;
+
+    ALTER TABLE collated_fti_lexemes DROP CONSTRAINT collated_fti_lexemes_context_fkey;
+
+    ALTER TABLE collated_fti_lexemes DROP CONSTRAINT collated_fti_lexemes_item_fkey;
+
+    DROP INDEX collated_fti_lexemes_item_fkey;
+
+    DROP INDEX collated_fti_lexemes_context_fkey;
+
+    DROP INDEX collated_fti_lexemes_context_item_idx;
+
+    DROP TRIGGER index_fulltext_lexeme ON modulefti;
+
+    DROP TRIGGER index_collated_fulltext_lexeme ON collated_fti;
+
+    DROP INDEX modulefti_lexemes_module_ident;
+
+    DROP TABLE collated_fti_lexemes;
+
+    DROP TABLE modulefti_lexemes;
+
+    DROP FUNCTION index_fulltext_lexeme_update_trigger();
+
+    DROP FUNCTION index_collated_fulltext_lexeme_update_trigger();
+    """)
+
+
+def down(cursor):
+    cursor.execute("""
+CREATE TABLE collated_fti_lexemes (
+    item integer,
+    context integer,
+    lexeme text,
+    positions integer[]);
+
+CREATE TABLE modulefti_lexemes (
+    module_ident integer,
+    lexeme text,
+    positions integer[]);
+
+CREATE OR REPLACE FUNCTION count_collated_lexemes(myident integer, bookident integer, mysearch text) RETURNS bigint
+    LANGUAGE sql STABLE
+    AS $_$
+     select sum(array_length(positions,1))
+            from collated_fti_lexemes,
+                 regexp_split_to_table(strip(to_tsvector(mysearch))::text,' ') s
+            where item = myident and context = bookident and lexeme = substr(s,2,length(s)-2)
+$_$;
+
+ALTER FUNCTION count_collated_lexemes(myident integer, bookident integer, mysearch text) OWNER TO reedstrm;
+
+CREATE OR REPLACE FUNCTION count_lexemes(myident integer, mysearch text) RETURNS bigint
+    LANGUAGE sql STABLE
+    AS $_$
+     select sum(array_length(positions,1))
+            from modulefti_lexemes,
+                 regexp_split_to_table(strip(to_tsvector(mysearch))::text,' ') s
+            where module_ident = myident and lexeme = substr(s,2,length(s)-2)
+$_$;
+
+CREATE FUNCTION index_collated_fulltext_lexeme_update_trigger() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $_$
+  BEGIN
+
+    DELETE from collated_fti_lexemes where item = NEW.item AND context = NEW.context;
+
+    INSERT into collated_fti_lexemes (item, context, lexeme, positions)
+       (with lex as (SELECT regexp_split_to_table(NEW.module_idx::text, E' \\'') as t )
+       SELECT NEW.item, NEW.context,
+              substring(t,1,strpos(t,E'\\':')-1),
+              ('{'||substring(t,strpos(t,E'\\':')+2)||'}')::int[] from lex) ;
+
+  RETURN NEW;
+  END;
+  $_$;
+
+CREATE FUNCTION index_fulltext_lexeme_update_trigger() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $_$
+  BEGIN
+
+    DELETE from modulefti_lexemes where module_ident = NEW.module_ident;
+
+    INSERT into modulefti_lexemes (module_ident, lexeme, positions)
+       (with lex as (SELECT regexp_split_to_table(NEW.module_idx::text, E' \\'') as t )
+       SELECT NEW.module_ident,
+              substring(t,1,strpos(t,E'\\':')-1),
+              ('{'||substring(t,strpos(t,E'\\':')+2)||'}')::int[] from lex) ;
+
+  RETURN NEW;
+  END;
+  $_$;
+
+CREATE INDEX collated_fti_lexemes_context_fkey ON collated_fti_lexemes (context);
+
+CREATE INDEX collated_fti_lexemes_context_item_idx ON collated_fti_lexemes (context, item);
+
+CREATE INDEX collated_fti_lexemes_item_fkey ON collated_fti_lexemes (item);
+
+CREATE INDEX modulefti_lexemes_module_ident ON modulefti_lexemes (module_ident);
+
+CREATE TRIGGER index_collated_fulltext_lexeme
+    BEFORE INSERT OR UPDATE ON collated_fti
+    FOR EACH ROW
+    EXECUTE PROCEDURE index_collated_fulltext_lexeme_update_trigger();
+
+CREATE TRIGGER index_fulltext_lexeme
+    BEFORE INSERT OR UPDATE ON modulefti
+    FOR EACH ROW
+    EXECUTE PROCEDURE index_fulltext_lexeme_update_trigger();
+
+ALTER TABLE collated_fti_lexemes ADD CONSTRAINT collated_fti_lexemes_context_fkey FOREIGN KEY (context) REFERENCES modules (module_ident) ON DELETE CASCADE;
+
+ALTER TABLE collated_fti_lexemes ADD CONSTRAINT collated_fti_lexemes_item_fkey FOREIGN KEY (item) REFERENCES modules (module_ident) ON DELETE CASCADE;
+
+ALTER TABLE modulefti_lexemes ADD CONSTRAINT modulefti_lexemes_module_ident_fkey FOREIGN KEY (module_ident) REFERENCES modules (module_ident) ON DELETE CASCADE;
+    """)

--- a/cnxdb/migrations/20170926044408_book-fulltext-index.py
+++ b/cnxdb/migrations/20170926044408_book-fulltext-index.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION index_fulltext_book_trigger() RETURNS trigger
+        LANGUAGE plpgsql
+        AS $_$
+      BEGIN
+        DELETE from modulefti WHERE module_ident = NEW.module_ident;
+        PERFORM insert_book_fti(NEW.module_ident);
+        RETURN NULL;
+      END;
+      $_$;
+
+    CREATE AGGREGATE tsvector_agg (
+          BASETYPE = tsvector,
+          SFUNC = tsvector_concat,
+          STYPE = tsvector,
+          INITCOND = ''
+        );
+
+    CREATE OR REPLACE FUNCTION insert_book_fti(bookid integer) RETURNS void
+        LANGUAGE sql
+        AS $_$
+        WITH RECURSIVE t(node, parent, document, path) AS (
+            SELECT tr.nodeid, tr.parent_id, tr.documentid, ARRAY[tr.nodeid]
+            FROM trees tr
+            WHERE tr.documentid = bookid and tr.is_collated = 'False'
+          UNION ALL
+            SELECT c.nodeid, c.parent_id, c.documentid, path || ARRAY[c.nodeid]
+            FROM trees c JOIN t ON c.parent_id = t.node
+            WHERE NOT c.nodeid = ANY(t.path)
+          )
+        INSERT INTO modulefti (module_ident, module_idx)
+             SELECT bookid, tsvector_agg(mf.module_idx)
+          FROM t JOIN modulefti mf
+            ON t.document = mf.module_ident JOIN modules m
+            ON t.document = m.module_ident
+          WHERE m.portal_type IN ('Module','CompositeModule')
+        $_$;
+
+    CREATE TRIGGER index_fulltext_book
+        AFTER INSERT OR UPDATE ON latest_modules
+        FOR EACH ROW
+        WHEN ((new.portal_type = 'Collection'::text))
+        EXECUTE PROCEDURE index_fulltext_book_trigger();
+    """)
+
+
+def down(cursor):
+    cursor.execute("""
+    DROP TRIGGER index_fulltext_book ON latest_modules;
+    DROP FUNCTION insert_book_fti(bookid integer);
+    DROP FUNCTION index_fulltext_book_trigger();
+    DROP AGGREGATE tsvector_agg(tsvector);
+    """)

--- a/cnxdb/migrations/20170926045602_book-fulltext-index-data.py
+++ b/cnxdb/migrations/20170926045602_book-fulltext-index-data.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+import time
+from datetime import timedelta
+
+from dbmigrator import deferred, logger
+
+
+def _batcher(seq, size):
+    for pos in range(0, len(seq), size):
+        yield seq[pos:pos + size]
+
+
+def should_run(cursor):
+    cursor.execute("""
+    SELECT module_ident FROM latest_modules lm WHERE
+    portal_type = 'Collection' AND
+    NOT EXISTS (SELECT 1 FROM modulefti mf
+        WHERE lm.module_ident = mf.module_ident)""")
+    return cursor.fetchall()
+
+
+@deferred
+def up(cursor):
+    """Create fulltext indexes for books"""
+    to_index = should_run(cursor)
+    num_todo = len(to_index)
+
+    batch_size = 100
+    logger.info('Books to index {}'.format(num_todo))
+    logger.info('Batch size: {}'.format(batch_size))
+
+    start = time.time()
+    guesstimate = 0.01 * num_todo
+    guess_complete = guesstimate + start
+    logger.info('Completion guess: '
+                '"{}" ({})'.format(time.ctime(guess_complete),
+                                   timedelta(0, guesstimate)))
+
+    module_idents = tuple([i[0] for i in to_index])
+    num_complete = 0
+    for batch in _batcher(module_idents, batch_size):
+
+        for module_ident in batch:
+            cursor.execute("SELECT insert_book_fti(%(module_ident)s)",
+                           {'module_ident': module_ident})
+
+        cursor.connection.commit()
+        num_complete += len(batch)
+        percent_comp = num_complete * 100.0 / num_todo
+        elapsed = time.time() - start
+        remaining_est = elapsed * (num_todo - num_complete) / num_complete
+        est_complete = start + elapsed + remaining_est
+        logger.info('{:.1f}% complete '
+                    'est: "{}" ({})'.format(percent_comp,
+                                            time.ctime(est_complete),
+                                            timedelta(0, remaining_est)))
+
+    logger.info('Total runtime: {}'.format(timedelta(0, elapsed)))
+
+
+def down(cursor):
+    """Delete book fulltext indexes"""
+    cursor.execute("""\
+            DELETE FROM modulefti mf WHERE EXISTS
+                (SELECT 1 FROM modules m
+                    WHERE m.module_ident = mf.module_ident)
+""")

--- a/cnxdb/migrations/20170926132743_sha1-functions.py
+++ b/cnxdb/migrations/20170926132743_sha1-functions.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from dbmigrator import super_user
+from psycopg2 import sql
+
+
+def up(cursor):
+    pg_user = cursor.connection.get_dsn_parameters()['user']
+    with super_user() as super_cursor:
+        super_cursor.execute("""\
+            CREATE OR REPLACE FUNCTION sha1(file text)
+             RETURNS text
+             LANGUAGE plpythonu
+             IMMUTABLE STRICT
+            AS $function$
+            import hashlib
+            return hashlib.new('sha1', file).hexdigest()
+            $function$;
+            """)
+
+        super_cursor.execute(sql.SQL('alter function sha1(text) owner to {}'
+                                     ).format(sql.Identifier(pg_user)))
+
+        super_cursor.execute("""\
+            CREATE OR REPLACE FUNCTION sha1(f bytea)
+             RETURNS text
+             LANGUAGE plpythonu
+            AS $function$
+            import hashlib
+            return hashlib.new('sha1',f).hexdigest()
+            $function$
+            """)
+
+        super_cursor.execute(sql.SQL('alter function sha1(bytea) owner to {}'
+                                     ).format(sql.Identifier(pg_user)))
+
+
+def down(cursor):
+    with super_user() as super_cursor:
+        super_cursor.execute("DROP FUNCTION sha1(text)")
+        super_cursor.execute("DROP FUNCTION sha1(bytea)")

--- a/tests/schema/test_triggers.py
+++ b/tests/schema/test_triggers.py
@@ -96,6 +96,7 @@ INSERT INTO abstracts
 VALUES (1, 'test')""")
             db_cursor.execute("""\
 ALTER TABLE modules DISABLE TRIGGER USER;
+ALTER TABLE latest_modules DISABLE TRIGGER USER;
 ALTER TABLE modules ENABLE TRIGGER update_latest_version;""")
             db_cursor.execute("""\
 INSERT INTO latest_modules (moduleid, version, name, \


### PR DESCRIPTION
This PR does 3 things:
  1. create book fulltext vector (full text index) from the component vectors of the pages that book contains
  2. improve lexeme counting for in book search by using `ts_stat` funtion, instead of a prebuilt table. This removes a nasty string-parsing hack from the publishing path, as well as removing a couple tables from the DB.
 3. missing functions (`sha1`) that are in the production DB, as well as migrations, but never were added to the base schema.