### PR TITLE
Add migration for print_style_recipes

### DIFF
--- a/cnxdb/archive-sql/schema/tables.sql
+++ b/cnxdb/archive-sql/schema/tables.sql
@@ -278,6 +278,10 @@ CREATE TABLE print_style_recipes (
       -- future may have 'pdf' or other cases
   revised TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
       -- time of upload to the archive db
+  title TEXT,
+      -- long human understandable name for print style (for menus, etc.)
+  commit_id text,
+      -- a string to further identify what version recipe (commit hash?)
   FOREIGN KEY (fileid) REFERENCES files (fileid),
   PRIMARY KEY (print_style, tag)
       -- allow a recipe per each version of print_style
@@ -296,5 +300,9 @@ CREATE TABLE default_print_style_recipes (
       -- default recipe for this particular print_style 
   recipe_type TEXT,
   revised TIMESTAMP WITH TIME ZONE NOT NULL,
+  title TEXT,
+      -- long human understandable name for print style (for menus, etc.)
+  commit_id text,
+      -- a string to further identify what version recipe (commit hash?)
   FOREIGN KEY (fileid) REFERENCES files (fileid)
 );

--- a/cnxdb/archive-sql/schema/triggers.sql
+++ b/cnxdb/archive-sql/schema/triggers.sql
@@ -248,54 +248,67 @@ CREATE TRIGGER ruleset_trigger
 
 -- recipe maintenace triggers
 
-CREATE OR REPLACE FUNCTION update_default_recipes() RETURNS trigger AS '
+CREATE OR REPLACE FUNCTION update_default_recipes() RETURNS trigger AS $$
 BEGIN
-  IF (TG_OP = ''INSERT'' OR TG_OP = ''UPDATE'') AND
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') AND
           NEW.revised >= ((SELECT revised FROM print_style_recipes
               WHERE print_style = NEW.print_style ORDER BY revised DESC LIMIT 1)
-              UNION ALL VALUES (NEW.revised) LIMIT 1)
+              UNION ALL VALUES (NEW.revised) LIMIT 1) -- avoid compare to NULL
   THEN
       DELETE FROM default_print_style_recipes WHERE print_style = NEW.print_style;
       INSERT into default_print_style_recipes (
-        print_style, tag, fileid, recipe_type, revised)
+        print_style, title, tag, commit_id, fileid, recipe_type, revised)
   	VALUES (
-        NEW.print_style, NEW.tag, NEW.fileid, NEW.recipe_type, NEW.revised);
+        NEW.print_style, NEW.title, NEW.tag, NEW.commit_id, NEW.fileid, NEW.recipe_type, NEW.revised);
   END IF;
 
-  IF TG_OP = ''UPDATE'' THEN
-      UPDATE default_print_style_recipes SET
-        fileid=NEW.fileid,
-        recipe_type=NEW.recipe_type,
-        revised=NEW.revised
-        WHERE print_style=NEW.print_style AND tag=NEW.tag;
+  IF TG_OP = 'UPDATE' THEN
+    PERFORM 1 from modules where recipe = OLD.fileid;
+    IF FOUND and NEW.fileid != OLD.fileid THEN
+        RAISE WARNING 'Cannot change recipe file: recipe in use';
+        RETURN NULL;
+    END IF;
+    UPDATE default_print_style_recipes SET
+      tag=NEW.tag,
+      title=NEW.title,
+      fileid=NEW.fileid,
+      recipe_type=NEW.recipe_type
+      WHERE print_style=NEW.print_style and revised=NEW.revised;
   END IF;
 
 RETURN NEW;
 END;
 
-' LANGUAGE 'plpgsql';
+$$ LANGUAGE 'plpgsql';
 
 CREATE TRIGGER update_default_recipes
   BEFORE INSERT OR UPDATE ON print_style_recipes FOR EACH ROW
   EXECUTE PROCEDURE update_default_recipes();
 
 
-CREATE OR REPLACE FUNCTION delete_from_default_recipes() RETURNS trigger AS '
+CREATE OR REPLACE FUNCTION delete_from_default_recipes() RETURNS trigger AS $$
 BEGIN
-  DELETE FROM  default_print_style_recipes
-    WHERE print_style=OLD.print_style and tag=OLD.tag;
+  PERFORM 1 FROM modules where recipe = OLD.fileid;
   IF FOUND THEN
-    INSERT into default_print_style_recipes (
-        print_style, tag, fileid, recipe_type, revised)
-    SELECT DISTINCT ON (print_style)
-        print_style, tag, fileid, recipe_type, max(revised)
-    from print_style_recipes where print_style=OLD.print_style
-    order by revised desc;
+    RAISE WARNING 'Cannot delete: recipe in use';
+    RETURN NULL;
+  ELSE
+    DELETE FROM  default_print_style_recipes
+      WHERE print_style=OLD.print_style and tag=OLD.tag;
+    IF FOUND THEN
+      INSERT into default_print_style_recipes (
+          print_style, title, tag, commit_id, fileid, recipe_type, revised)
+      SELECT 
+          print_style, title, tag, commit_id, fileid, recipe_type, revised
+      from print_style_recipes where print_style=OLD.print_style
+                                   and tag != OLD.tag
+      order by revised desc LIMIT 1;
+    END IF;
+    RETURN OLD;
   END IF;
-  RETURN OLD;
 END;
-' LANGUAGE 'plpgsql';
+$$ LANGUAGE 'plpgsql';
 
 CREATE TRIGGER delete_from_default_recipes
-  AFTER DELETE ON print_style_recipes FOR EACH ROW
+  BEFORE DELETE ON print_style_recipes FOR EACH ROW
   EXECUTE PROCEDURE delete_from_default_recipes();

--- a/cnxdb/migrations/20171009211647_fix-print-style.py
+++ b/cnxdb/migrations/20171009211647_fix-print-style.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+
+
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
+def up(cursor):
+    cursor.execute("""\
+    ALTER TABLE print_style_recipes
+       ADD COLUMN title text,
+       ADD COLUMN commit_id text
+       """)
+    cursor.execute("""\
+    ALTER TABLE default_print_style_recipes
+       ADD COLUMN title text,
+       ADD COLUMN commit_id text
+       """)
+    cursor.execute("""\
+CREATE OR REPLACE FUNCTION update_default_recipes() RETURNS trigger AS $$
+BEGIN
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') AND
+          NEW.revised >= ((SELECT revised FROM print_style_recipes
+              WHERE print_style = NEW.print_style ORDER BY revised DESC LIMIT 1)
+              UNION ALL VALUES (NEW.revised) LIMIT 1) -- avoid compare to NULL
+  THEN
+      DELETE FROM default_print_style_recipes WHERE print_style = NEW.print_style;
+      INSERT into default_print_style_recipes (
+        print_style, title, tag, commit_id, fileid, recipe_type, revised)
+    VALUES (
+        NEW.print_style, NEW.title, NEW.tag, NEW.commit_id, NEW.fileid, NEW.recipe_type, NEW.revised);
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    PERFORM 1 from modules where recipe = OLD.fileid;
+    IF FOUND and NEW.fileid != OLD.fileid THEN
+        RAISE WARNING 'Cannot change recipe file: recipe in use';
+        RETURN NULL;
+    END IF;
+    UPDATE default_print_style_recipes SET
+      tag=NEW.tag,
+      title=NEW.title,
+      fileid=NEW.fileid,
+      recipe_type=NEW.recipe_type
+      WHERE print_style=NEW.print_style and revised=NEW.revised;
+  END IF;
+
+RETURN NEW;
+END;
+
+$$ LANGUAGE 'plpgsql';
+""")
+    cursor.execute("""\
+CREATE OR REPLACE FUNCTION delete_from_default_recipes() RETURNS trigger AS $$
+BEGIN
+  PERFORM 1 FROM modules where recipe = OLD.fileid;
+  IF FOUND THEN
+    RAISE WARNING 'Cannot delete: recipe in use';
+    RETURN NULL;
+  ELSE
+    DELETE FROM  default_print_style_recipes
+      WHERE print_style=OLD.print_style and tag=OLD.tag;
+    IF FOUND THEN
+      INSERT into default_print_style_recipes (
+          print_style, title, tag, commit_id, fileid, recipe_type, revised)
+      SELECT
+          print_style, title, tag, commit_id, fileid, recipe_type, revised
+      from print_style_recipes where print_style=OLD.print_style
+                                   and tag != OLD.tag
+      order by revised desc LIMIT 1;
+    END IF;
+    RETURN OLD;
+  END IF;
+END;
+$$ LANGUAGE 'plpgsql';
+""")
+    cursor.execute("""\
+DROP TRIGGER IF EXISTS delete_from_default_recipes
+ON print_style_recipes;
+CREATE TRIGGER delete_from_default_recipes
+  BEFORE DELETE ON print_style_recipes FOR EACH ROW
+  EXECUTE PROCEDURE delete_from_default_recipes();
+""")
+
+
+def down(cursor):
+    cursor.execute("""\
+    ALTER TABLE print_style_recipes
+       DROP COLUMN title,
+       DROP COLUMN commit_id
+       """)
+    cursor.execute("""\
+    ALTER TABLE default_print_style_recipes
+       DROP COLUMN title,
+       DROP COLUMN commit_id
+       """)
+    cursor.execute("""\
+CREATE OR REPLACE FUNCTION public.update_default_recipes()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE') AND
+          NEW.revised >= ((SELECT revised FROM print_style_recipes
+              WHERE print_style = NEW.print_style ORDER BY revised DESC LIMIT 1)
+              UNION ALL VALUES (NEW.revised) LIMIT 1)
+  THEN
+      DELETE FROM default_print_style_recipes WHERE print_style = NEW.print_style;
+      INSERT into default_print_style_recipes (
+        print_style, tag, fileid, recipe_type, revised)
+    VALUES (
+        NEW.print_style, NEW.tag, NEW.fileid, NEW.recipe_type, NEW.revised);
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+      UPDATE default_print_style_recipes SET
+        fileid=NEW.fileid,
+        recipe_type=NEW.recipe_type,
+        revised=NEW.revised
+        WHERE print_style=NEW.print_style AND tag=NEW.tag;
+  END IF;
+
+RETURN NEW;
+END;
+
+$function$
+""")
+    cursor.execute("""\
+CREATE OR REPLACE FUNCTION public.delete_from_default_recipes()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  DELETE FROM  default_print_style_recipes
+    WHERE print_style=OLD.print_style and tag=OLD.tag;
+  IF FOUND THEN
+    INSERT into default_print_style_recipes (
+        print_style, tag, fileid, recipe_type, revised)
+    SELECT DISTINCT ON (print_style)
+        print_style, tag, fileid, recipe_type, max(revised)
+    from print_style_recipes where print_style=OLD.print_style
+    order by revised desc;
+  END IF;
+  RETURN OLD;
+END;
+$function$
+""")
+    cursor.execute("""\
+DROP TRIGGER IF EXISTS delete_from_default_recipes
+ON print_style_recipes;
+CREATE TRIGGER delete_from_default_recipes
+  AFTER DELETE ON print_style_recipes FOR EACH ROW
+  EXECUTE PROCEDURE delete_from_default_recipes();
+""")

--- a/cnxdb/migrations/20171010195430_install-recipes.py
+++ b/cnxdb/migrations/20171010195430_install-recipes.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import hashlib
+from psycopg2 import Binary
+try:
+    from cnxrecipes import recipes, _version, __version__ as recipe_tag
+    recipe_hash = _version.get_versions()['full-revisionid']
+except ImportError:
+    recipe_tag = None
+    recipes = []
+
+from dbmigrator import deferred
+
+
+def should_run(cursor):
+    cursor.execute('SELECT count(*) from print_style_recipes where tag = %s',
+                   (recipe_tag,))
+    installed_recipe_count = cursor.fetchall()[0][0]
+    return len(recipes) > 0 and installed_recipe_count == 0
+
+
+@deferred
+def up(cursor):
+    """Insert all the recipes using the package version"""
+    for recipe in recipes:
+        sha1 = hashlib.new('sha1', recipe['file']).hexdigest()
+        cursor.execute('SELECT fileid FROM files WHERE sha1 = %s', (sha1,))
+        if cursor.rowcount != 0:
+            fileid = cursor.fetchone()[0]
+        else:
+            cursor.execute("""INSERT INTO files (file) VALUES (%s)"""
+                           """ RETURNING fileid""", (Binary(recipe['file']),))
+            fileid = cursor.fetchone()[0]
+
+        cursor.execute("""INSERT INTO"""
+                       """ print_style_recipes"""
+                       """ (print_style, title, fileid, tag, commit_id)"""
+                       """ VALUES(%s, %s, %s, %s, %s)""",
+                       (recipe['id'], recipe['title'],
+                        fileid, recipe_tag, recipe_hash))
+
+
+def down(cursor):
+    """Delete any recipes from this package version"""
+    cursor.execute('DELETE FROM print_style_recipes WHERE tag = %s',
+                   (recipe_tag,))

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,5 +6,6 @@ mock==1.0.1;python_version<="2.7"
 git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
 git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
+git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
 # FIXME circular dependency here...
 git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive

--- a/script/ci_test_migrations.sh
+++ b/script/ci_test_migrations.sh
@@ -40,10 +40,13 @@ git checkout $current_commit
 pip install .
 
 # check the number of migrations that are going to run
-steps=$(dbmigrator --db-connection-string='dbname=testing user=tester' list | grep False | wc -l)
+applied_before=$(dbmigrator --db-connection-string='dbname=testing user=tester' list | awk 'NF>3 {applied+=1}; END {print applied}')
 
 # run the migrations
 dbmigrator --db-connection-string='dbname=testing user=tester' migrate --run-deferred
+
+applied_after=$(dbmigrator --db-connection-string='dbname=testing user=tester' list | awk 'NF>3 {applied+=1}; END {print applied}')
+steps=$((applied_after-applied_before))
 
 # store the schema
 pg_dump -s 'dbname=testing user=tester' >migrated_schema.sql


### PR DESCRIPTION
  - commit id for those who like that sort of thing
  - title for human readable name of print style

Fixes up the triggers for maintaining default_print_style as well.

Note that the migration test will not pass for two reasons: we managed to deploy mismatched schema vs. migrations  - the trigger as written in schema is not valid, but was corrected in the migration. I did not write the rollback to install the invalid trigger function. And two, the new schema and the migrated schema differ in column order for the tables that we add columns to. The text diff of pg_dump output would be difficult to make aware of this difference. This is a known behavior of postgresql. I don't want to bow to this implementation detail by adding all new columns at the end: we have an SQL policy of not depending on the default column order, in any case. Also, existing production schema differs in exactly this way from a new schema, due to past (by hand) migrations.