### PR TITLE
BUGFIX - print_style_recipe update trigger

### DIFF
--- a/cnxdb/archive-sql/schema/triggers.sql
+++ b/cnxdb/archive-sql/schema/triggers.sql
@@ -266,7 +266,7 @@ BEGIN
       UPDATE default_print_style_recipes SET
         fileid=NEW.fileid,
         recipe_type=NEW.recipe_type,
-        NEW.revised)
+        revised=NEW.revised
         WHERE print_style=NEW.print_style AND tag=NEW.tag;
   END IF;
 


### PR DESCRIPTION
Somehow, a mis-match between the schema and migrations slipped
through. This mini-PR fixes just the schema to match the as-deployed
code, which matches the existing migration in
20170614211640_print-style-recipes