### PR TITLE
make in book search OR terms, rather than AND them

### DIFF
--- a/cnxdb/archive-sql/get-in-book-search-full-page.sql
+++ b/cnxdb/archive-sql/get-in-book-search-full-page.sql
@@ -25,22 +25,22 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ),
 ts_headline(
 convert_from(f.file, 'utf8'),
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<mtext class=""q-match"">", StopSel="</mtext>", MaxFragments=0, HighlightAll=TRUE'
 ),
-ts_rank_cd(mft.module_idx, plainto_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(mft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
 FROM
  t left join  modules m on t.value = m.module_ident
         join modulefti mft on mft.module_ident = m.module_ident
         join module_files mf on m.module_ident = mf.module_ident
         join files f on mf.fileid = f.fileid
 WHERE
- mft.module_idx @@ plainto_tsquery(%(search_term)s)
+ mft.module_idx @@ plainto_or_tsquery(%(search_term)s)
  and mf.filename = 'index.cnxml.html'
  and m.uuid = (%(page_uuid)s)
 ORDER BY

--- a/cnxdb/archive-sql/get-in-book-search.sql
+++ b/cnxdb/archive-sql/get-in-book-search.sql
@@ -25,21 +25,21 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ) as title,
 ts_headline(fulltext,
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=1, MaxWords=20, MinWords=15,'
 ) as snippet,
 count_lexemes(mft.module_ident, %(search_term)s) as matches,
-ts_rank_cd(mft.module_idx, plainto_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(mft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
 FROM
  t left join  modules m on t.value = m.module_ident
         join modulefti mft on mft.module_ident = m.module_ident
         join module_files mf on m.module_ident = mf.module_ident
 WHERE
- mft.module_idx @@ plainto_tsquery(%(search_term)s)
+ mft.module_idx @@ plainto_or_tsquery(%(search_term)s)
  and mf.filename = 'index.cnxml.html'
 ORDER BY
  rank DESC,

--- a/cnxdb/archive-sql/get-in-collated-book-search-full-page.sql
+++ b/cnxdb/archive-sql/get-in-collated-book-search-full-page.sql
@@ -26,15 +26,15 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ),
 ts_headline(
 convert_from(f.file, 'utf8'),
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<mtext class=""q-match"">", StopSel="</mtext>", MaxFragments=0, HighlightAll=TRUE'
 ),
-ts_rank_cd(cft.module_idx, plainto_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(cft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
 FROM
  t left join modules m on t.value = m.module_ident
         join collated_fti cft on cft.item = m.module_ident
@@ -42,7 +42,7 @@ FROM
         join files f on cfa.fileid = f.fileid,
  modules AS book
 WHERE
- cft.module_idx @@ plainto_tsquery(%(search_term)s) AND 
+ cft.module_idx @@ plainto_or_tsquery(%(search_term)s) AND 
  m.uuid = (%(page_uuid)s) AND
  cft.context = book.module_ident AND
  cfa.context = book.module_ident AND

--- a/cnxdb/archive-sql/get-in-collated-book-search.sql
+++ b/cnxdb/archive-sql/get-in-collated-book-search.sql
@@ -26,15 +26,15 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ) as title,
 ts_headline(fulltext,
-plainto_tsquery(%(search_term)s),
+plainto_or_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=1, MaxWords=20, MinWords=15,'
 ) as snippet,
 count_collated_lexemes(cft.item, cft.context, %(search_term)s) as matches,
-ts_rank_cd(cft.module_idx, plainto_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(cft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
 FROM
  collated_fti cft join
  modules m on cft.item = m.module_ident join
@@ -42,7 +42,7 @@ FROM
 
 WHERE
  cft.context = t.docs[1] AND
- cft.module_idx @@ plainto_tsquery(%(search_term)s)
+ cft.module_idx @@ plainto_or_tsquery(%(search_term)s)
 ORDER BY
  rank DESC,
  t.path

--- a/cnxdb/archive-sql/schema/functions.sql
+++ b/cnxdb/archive-sql/schema/functions.sql
@@ -198,3 +198,7 @@ CREATE OR REPLACE FUNCTION short_ident_hash(uuid uuid, major integer, minor inte
  IMMUTABLE
 AS $function$ select short_id(uuid) || '@' || concat_ws('.', major, minor) $function$;
 
+CREATE OR REPLACE FUNCTION plainto_or_tsquery (TEXT) RETURNS tsquery AS $$
+  SELECT to_tsquery( regexp_replace( $1, E'[\\s\'|:&()!]+','|','g') );
+$$ LANGUAGE SQL STRICT IMMUTABLE;
+

--- a/cnxdb/migrations/20171012130959_inbook-search-or-terms.py
+++ b/cnxdb/migrations/20171012130959_inbook-search-or-terms.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""\
+CREATE OR REPLACE FUNCTION plainto_or_tsquery (TEXT) RETURNS tsquery AS $$
+  SELECT to_tsquery( regexp_replace( $1, E'[\\\\s\\'|:&()!]+','|','g') );
+$$ LANGUAGE SQL STRICT IMMUTABLE;
+""")
+
+
+def down(cursor):
+    cursor.execute("DROP FUNCTION plainto_or_tsquery (TEXT)")


### PR DESCRIPTION
Another in the series of "Ross can't fall asleep, so might as well code something" PRs

Was thinking about search. Now that it's possible to find books with terms that appear on different pages, it would be nice if doing the same search inside the book actually found and highlighted all of them.