### PR TITLE
Fix update latest trigger not adding new modules

### DIFF
--- a/cnxdb/archive-sql/schema/triggers.sql
+++ b/cnxdb/archive-sql/schema/triggers.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION update_latest() RETURNS trigger AS '
 BEGIN
   IF (TG_OP = ''INSERT'' OR TG_OP = ''UPDATE'') AND
           ARRAY [NEW.major_version, NEW.minor_version] >= (SELECT ARRAY [major_version, minor_version]
-            FROM latest_modules WHERE uuid = NEW.uuid ) AND
+            FROM latest_modules WHERE uuid = NEW.uuid UNION ALL SELECT ARRAY[0, NULL] LIMIT 1) AND
           NEW.stateid = 1 THEN
       LOCK TABLE latest_modules IN SHARE ROW EXCLUSIVE MODE;
       DELETE FROM latest_modules WHERE moduleid = NEW.moduleid OR uuid = NEW.uuid;

--- a/cnxdb/migrations/20171012231938_fix-update-latest-trigger.py
+++ b/cnxdb/migrations/20171012231938_fix-update-latest-trigger.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+CREATE OR REPLACE FUNCTION update_latest() RETURNS trigger AS '
+BEGIN
+  IF (TG_OP = ''INSERT'' OR TG_OP = ''UPDATE'') AND
+          ARRAY [NEW.major_version, NEW.minor_version] >= (SELECT ARRAY [major_version, minor_version]
+            FROM latest_modules WHERE uuid = NEW.uuid UNION ALL SELECT ARRAY[0, NULL] LIMIT 1) AND
+          NEW.stateid = 1 THEN
+      LOCK TABLE latest_modules IN SHARE ROW EXCLUSIVE MODE;
+      DELETE FROM latest_modules WHERE moduleid = NEW.moduleid OR uuid = NEW.uuid;
+      INSERT into latest_modules (
+                uuid, module_ident, portal_type, moduleid, version, name,
+                  created, revised, abstractid, stateid, doctype, licenseid,
+                  submitter,submitlog, parent, language,
+                authors, maintainers, licensors, parentauthors, google_analytics,
+                major_version, minor_version, print_style, baked, recipe)
+          VALUES (
+         NEW.uuid, NEW.module_ident, NEW.portal_type, NEW.moduleid, NEW.version, NEW.name,
+           NEW.created, NEW.revised, NEW.abstractid, NEW.stateid, NEW.doctype, NEW.licenseid,
+           NEW.submitter, NEW.submitlog, NEW.parent, NEW.language,
+         NEW.authors, NEW.maintainers, NEW.licensors, NEW.parentauthors, NEW.google_analytics,
+         NEW.major_version, NEW.minor_version, NEW.print_style, NEW.baked, NEW.recipe);
+  END IF;
+
+  IF TG_OP = ''UPDATE'' THEN
+      UPDATE latest_modules SET
+        uuid=NEW.uuid,
+        moduleid=NEW.moduleid,
+        portal_type=NEW.portal_type,
+        version=NEW.version,
+        name=NEW.name,
+        created=NEW.created,
+        revised=NEW.revised,
+        abstractid=NEW.abstractid,
+        stateid=NEW.stateid,
+        doctype=NEW.doctype,
+        licenseid=NEW.licenseid,
+        submitter=NEW.submitter,
+        submitlog=NEW.submitlog,
+        parent=NEW.parent,
+        language=NEW.language,
+        authors=NEW.authors,
+        maintainers=NEW.maintainers,
+        licensors=NEW.licensors,
+        parentauthors=NEW.parentauthors,
+        google_analytics=NEW.google_analytics,
+        major_version=NEW.major_version,
+        minor_version=NEW.minor_version,
+        print_style=NEW.print_style,
+        baked=NEW.baked,
+        recipe=NEW.recipe
+        WHERE module_ident=NEW.module_ident;
+  END IF;
+
+RETURN NEW;
+END;
+
+' LANGUAGE 'plpgsql';""")
+
+
+def down(cursor):
+    cursor.execute("""
+CREATE OR REPLACE FUNCTION update_latest() RETURNS trigger AS '
+BEGIN
+  IF (TG_OP = ''INSERT'' OR TG_OP = ''UPDATE'') AND
+          ARRAY [NEW.major_version, NEW.minor_version] >= (SELECT ARRAY [major_version, minor_version]
+            FROM latest_modules WHERE uuid = NEW.uuid ) AND
+          NEW.stateid = 1 THEN
+      LOCK TABLE latest_modules IN SHARE ROW EXCLUSIVE MODE;
+      DELETE FROM latest_modules WHERE moduleid = NEW.moduleid OR uuid = NEW.uuid;
+      INSERT into latest_modules (
+                uuid, module_ident, portal_type, moduleid, version, name,
+                  created, revised, abstractid, stateid, doctype, licenseid,
+                  submitter,submitlog, parent, language,
+                authors, maintainers, licensors, parentauthors, google_analytics,
+                major_version, minor_version, print_style, baked, recipe)
+          VALUES (
+         NEW.uuid, NEW.module_ident, NEW.portal_type, NEW.moduleid, NEW.version, NEW.name,
+           NEW.created, NEW.revised, NEW.abstractid, NEW.stateid, NEW.doctype, NEW.licenseid,
+           NEW.submitter, NEW.submitlog, NEW.parent, NEW.language,
+         NEW.authors, NEW.maintainers, NEW.licensors, NEW.parentauthors, NEW.google_analytics,
+         NEW.major_version, NEW.minor_version, NEW.print_style, NEW.baked, NEW.recipe);
+  END IF;
+
+  IF TG_OP = ''UPDATE'' THEN
+      UPDATE latest_modules SET
+        uuid=NEW.uuid,
+        moduleid=NEW.moduleid,
+        portal_type=NEW.portal_type,
+        version=NEW.version,
+        name=NEW.name,
+        created=NEW.created,
+        revised=NEW.revised,
+        abstractid=NEW.abstractid,
+        stateid=NEW.stateid,
+        doctype=NEW.doctype,
+        licenseid=NEW.licenseid,
+        submitter=NEW.submitter,
+        submitlog=NEW.submitlog,
+        parent=NEW.parent,
+        language=NEW.language,
+        authors=NEW.authors,
+        maintainers=NEW.maintainers,
+        licensors=NEW.licensors,
+        parentauthors=NEW.parentauthors,
+        google_analytics=NEW.google_analytics,
+        major_version=NEW.major_version,
+        minor_version=NEW.minor_version,
+        print_style=NEW.print_style,
+        baked=NEW.baked,
+        recipe=NEW.recipe
+        WHERE module_ident=NEW.module_ident;
+  END IF;
+
+RETURN NEW;
+END;
+
+' LANGUAGE 'plpgsql';""")


### PR DESCRIPTION
We changed the condition for adding modules to the latest_modules table
from just comparing the "revised" field to comparing the major and minor
versions:

```
ARRAY [NEW.major_version, NEW.minor_version] >= (
    SELECT ARRAY [major_version, minor_version]
    FROM latest_modules WHERE uuid = NEW.uuid)
```

This works ok when the uuid is found in the latest_modules table, it
doesn't work when the uuid doesn't exist.  For example:

```
cnxarchive=# SELECT 1 WHERE ARRAY [2, NULL] >= (
cnxarchive-#     SELECT ARRAY [major_version, minor_version] FROM latest_modules WHERE 1 = 0);
 ?column?
----------
(0 rows)
```

It appears `ARRAY [2, NULL] >= NULL` is false.  To fix this, adding
`UNION ALL SELECT ARRAY[0, NULL] LIMIT 1` seems to work.