### PR TITLE
Correct project testing requirements to also use main.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,5 @@ envlist = py27,py3
 [testenv]
 deps=
     -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/main.txt
 commands=py.test


### PR DESCRIPTION
This needs added in order to install our package requirements. Technically the setup.py does this, but we also want the requirements file to pin if necessary.