### PR TITLE
provide query_type parameterization for AND vs OR queries in-book-search

### DIFF
--- a/cnxdb/archive-sql/get-in-book-search-full-page.sql
+++ b/cnxdb/archive-sql/get-in-book-search-full-page.sql
@@ -25,22 +25,22 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ),
 ts_headline(
 convert_from(f.file, 'utf8'),
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<mtext class=""q-match"">", StopSel="</mtext>", MaxFragments=0, HighlightAll=TRUE'
 ),
-ts_rank_cd(mft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(mft.module_idx, plainto{combiner}_tsquery(%(search_term)s)) AS rank
 FROM
  t left join  modules m on t.value = m.module_ident
         join modulefti mft on mft.module_ident = m.module_ident
         join module_files mf on m.module_ident = mf.module_ident
         join files f on mf.fileid = f.fileid
 WHERE
- mft.module_idx @@ plainto_or_tsquery(%(search_term)s)
+ mft.module_idx @@ plainto{combiner}_tsquery(%(search_term)s)
  and mf.filename = 'index.cnxml.html'
  and m.uuid = (%(page_uuid)s)
 ORDER BY

--- a/cnxdb/archive-sql/get-in-book-search.sql
+++ b/cnxdb/archive-sql/get-in-book-search.sql
@@ -25,21 +25,21 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ) as title,
 ts_headline(fulltext,
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=1, MaxWords=20, MinWords=15,'
 ) as snippet,
 count_lexemes(mft.module_ident, %(search_term)s) as matches,
-ts_rank_cd(mft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(mft.module_idx, plainto{combiner}_tsquery(%(search_term)s)) AS rank
 FROM
  t left join  modules m on t.value = m.module_ident
         join modulefti mft on mft.module_ident = m.module_ident
         join module_files mf on m.module_ident = mf.module_ident
 WHERE
- mft.module_idx @@ plainto_or_tsquery(%(search_term)s)
+ mft.module_idx @@ plainto{combiner}_tsquery(%(search_term)s)
  and mf.filename = 'index.cnxml.html'
 ORDER BY
  rank DESC,

--- a/cnxdb/archive-sql/get-in-collated-book-search-full-page.sql
+++ b/cnxdb/archive-sql/get-in-collated-book-search-full-page.sql
@@ -26,15 +26,15 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ),
 ts_headline(
 convert_from(f.file, 'utf8'),
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<mtext class=""q-match"">", StopSel="</mtext>", MaxFragments=0, HighlightAll=TRUE'
 ),
-ts_rank_cd(cft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(cft.module_idx, plainto{combiner}_tsquery(%(search_term)s)) AS rank
 FROM
  t left join modules m on t.value = m.module_ident
         join collated_fti cft on cft.item = m.module_ident
@@ -42,7 +42,7 @@ FROM
         join files f on cfa.fileid = f.fileid,
  modules AS book
 WHERE
- cft.module_idx @@ plainto_or_tsquery(%(search_term)s) AND 
+ cft.module_idx @@ plainto{combiner}_tsquery(%(search_term)s) AND 
  m.uuid = (%(page_uuid)s) AND
  cft.context = book.module_ident AND
  cfa.context = book.module_ident AND

--- a/cnxdb/archive-sql/get-in-collated-book-search.sql
+++ b/cnxdb/archive-sql/get-in-collated-book-search.sql
@@ -26,15 +26,15 @@ SELECT
 m.uuid,
 m.major_version as version,
 ts_headline(COALESCE(t.title, m.name),
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=0, HighlightAll=TRUE'
 ) as title,
 ts_headline(fulltext,
-plainto_or_tsquery(%(search_term)s),
+plainto{combiner}_tsquery(%(search_term)s),
 E'StartSel="<span class=""q-match"">", StopSel="</span>", MaxFragments=1, MaxWords=20, MinWords=15,'
 ) as snippet,
 count_collated_lexemes(cft.item, cft.context, %(search_term)s) as matches,
-ts_rank_cd(cft.module_idx, plainto_or_tsquery(%(search_term)s)) AS rank
+ts_rank_cd(cft.module_idx, plainto{combiner}_tsquery(%(search_term)s)) AS rank
 FROM
  collated_fti cft join
  modules m on cft.item = m.module_ident join
@@ -42,7 +42,7 @@ FROM
 
 WHERE
  cft.context = t.docs[1] AND
- cft.module_idx @@ plainto_or_tsquery(%(search_term)s)
+ cft.module_idx @@ plainto{combiner}_tsquery(%(search_term)s)
 ORDER BY
  rank DESC,
  t.path


### PR DESCRIPTION
Further discussion w/ QA leads me to believe that "OR" is not the best default for in book search. This provides a parameter to select the combining boolean, defaulting to "AND"