### PR TITLE
Ignore linting of build and dist directories

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [flake8]
-exclude = *.egg,.state,.tox,setup.py,build/lib,cnxdb/migrations,docs/conf.py,cnxdb/archive-sql/schema/*.py
+exclude = *.egg,.state,.tox,setup.py,build/lib/,dist/,cnxdb/migrations,docs/conf.py,cnxdb/archive-sql/schema/*.py
 select = E,W,F,N
 
 [doc8]


### PR DESCRIPTION
Just a small fix to ignore the dist directory. I believe I made this commit before the build directory was on this line, which is why the commit still says "build and dist".