### PR TITLE
Wrap lines in docs/changes.rst

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,9 +9,13 @@
 0.11.0
 ------
 
-- In book search to provide query_type parameterization for AND vs OR queries (#87)
+- In book search to provide query_type parameterization for AND vs OR queries
+  (#87)
 - Fix number of migrations to rollback in ci_test_migrations.sh
-- get only the highest version for each book a page is in, return full ident_hash, as well as authors. Put same-as-page-authors first, since this is likely to be the orginal book the page was published in.  Returned as list of hashes in page content-extras
+- get only the highest version for each book a page is in, return full
+  ident_hash, as well as authors. Put same-as-page-authors first, since this is
+  likely to be the orginal book the page was published in.  Returned as list of
+  hashes in page content-extras
 - Correct project testing requirements to also use main.txt (#85)
 - Fix update latest trigger not adding new modules
 - make in book search OR terms, rather than AND them


### PR DESCRIPTION
`doc8` reported that the lines under v0.11.0 in docs/changes.rst are too
long:

```
docs/changes.rst:12: D001 Line too long
docs/changes.rst:14: D001 Line too long
```

Sorry :bowing_woman: 