### PR TITLE
Fix travis coverage 0% for python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - pip install -r requirements/test.txt
   - pip install codecov
 install:
-  - pip install .
+  - pip install -e .
 before_script:
   # Set up postgres roles
   - sudo -u postgres psql -d postgres -c "CREATE USER tester WITH SUPERUSER PASSWORD 'tester';"


### PR DESCRIPTION
I think what happened was we did `pip install .` which means that cnxdb
that was getting tested was in `lib/python2.7/site-packages` instead of
the one in the current directory.  That was probably why the coverage
was 0%.

Changing `pip install .` to `pip install -e .` means we are going to use
the cnxdb in the current directory and should fix this coverage problem.