### PR TITLE
Correct code coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,10 @@
 [run]
-omit =
-  cnxdb/tests/*
 
 [report]
 omit =
-  cnxdb/contrib/pytest.py
-  cnxdb/contrib/testing.py
-  cnxdb/tests/*
-  cnxdb/_version.py
-  cnxdb/__init__.py
+  *cnxdb/contrib/pytest.py
+  *cnxdb/contrib/testing.py
+  *cnxdb/_version.py
+  *cnxdb/__init__.py
 exclude_lines =
   pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_install:
   - pip install -r requirements/test.txt
   - pip install codecov
 install:
+  # Uninstall, because cnx-archive installs it due to the circular dependence.
+  - pip uninstall -y cnx-db
   - pip install .
 before_script:
   # Set up postgres roles
@@ -37,9 +39,11 @@ before_script:
   - cd session_exec
   - make USE_PGXS=1 -e && sudo make USE_PGXS=1 -e install
   - cd ..
+  - export PYPREFIX=$(python -c 'import sys; print(sys.prefix)')
+  - export PYVERDIR=$(python -c 'import sys; print("python%d.%d" % sys.version_info[:2])')
 script:
   # This is the same as `python setup.py test` with a coverage wrapper.
-  - py.test
+  - py.test --cov="$PYPREFIX/lib/$PYVERDIR/site-packages/cnxdb"
   # Test migrations
   - script/ci_test_migrations.sh
 after_success:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ parentdir_prefix =
 
 [tool:pytest]
 norecursedirs = build dist *.egg-info requirements .state .tox
-addopts = -rxs -v --cov-config .coveragerc --cov=cnxdb
+addopts = -rxs -v --cov-config .coveragerc

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = py27,py3
 deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/main.txt
-commands=py.test
+commands=py.test --cov={envsitepackagesdir}/cnxdb


### PR DESCRIPTION
This removes general coverage from a plain `pytest` command run, but it will do the right thing for `make test` (tox run) and travis.

This is a different approach to what #93 attempts to solve.