### PR TITLE
Add Pyramid integration 

### DIFF
--- a/cnxdb/config.py
+++ b/cnxdb/config.py
@@ -3,9 +3,10 @@ import os
 __all__ = ('discover_settings')
 
 
-def discover_settings():
+def discover_settings(settings=None):
     """Discover settings from environment variables
 
+    :param dict settings: An existing settings value
     :return: dictionary of settings
     :rtype: dict
 
@@ -21,8 +22,13 @@ def discover_settings():
     if common_url is None:
         raise RuntimeError("'DB_URL' environment variable must be defined")
 
-    settings = {
+    new_settings = {
         'db.common.url': common_url,
         'db.super.url': super_url,
     }
+
+    if settings is None:
+        settings = {}
+    for k, v in new_settings.items():
+        settings.setdefault(k, v)
     return settings

--- a/cnxdb/config.py
+++ b/cnxdb/config.py
@@ -16,19 +16,21 @@ def discover_settings(settings=None):
        defaults and required settings.
 
     """
+    if settings is None:
+        settings = {}
+
     common_url = os.environ.get('DB_URL', None)
     super_url = os.environ.get('DB_SUPER_URL', common_url)
 
-    if common_url is None:
-        raise RuntimeError("'DB_URL' environment variable must be defined")
+    if common_url is None and settings.get('db.common.url') is None:
+        raise RuntimeError("'DB_URL' environment variable "
+                           "OR the 'db.common.url' setting MUST be defined")
 
     new_settings = {
         'db.common.url': common_url,
         'db.super.url': super_url,
     }
 
-    if settings is None:
-        settings = {}
     for k, v in new_settings.items():
         settings.setdefault(k, v)
     return settings

--- a/cnxdb/contrib/pyramid.py
+++ b/cnxdb/contrib/pyramid.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""\
+When used in conjunction with the `Pyramid Web Framework
+<http://docs.pylonsproject.org/projects/pyramid/en/latest/>`_
+this module will setup the cnx-db library within the Pyramid application.
+
+"""
+from cnxdb.scripting import prepare
+
+
+__all__ = ('includeme',)
+
+
+def includeme(config):
+    """Used by pyramid to include this package.
+
+    This sets up a dictionary of engines for use.
+    They can be retrieved via the registry at ``registry.engines``.
+
+    """
+    env = prepare(config.registry.settings)
+    config.registry.engines = env['engines']

--- a/cnxdb/scripting.py
+++ b/cnxdb/scripting.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from cnxdb.config import discover_settings
 
 
-def prepare():
+def prepare(settings=None):
     """This function prepares an application/script for use with this codebase.
 
     :return: an environment dictionary containing the newly created
@@ -17,7 +17,7 @@ def prepare():
 
     """
     # Get the settings
-    settings = discover_settings()
+    settings = discover_settings(settings)
     engines = {
         'common': create_engine(settings['db.common.url']),
         'super': create_engine(settings['db.super.url']),

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,12 @@ Testing (:mod:`cnxdb.contrib.testing`)
 .. automodule:: cnxdb.contrib.testing
    :members:
 
+Pyramid (:mod:`cnxdb.contrib.pyramid`)
+--------------------------------------
+
+.. automodule:: cnxdb.contrib.pyramid
+   :members:
+
 Pytest (:mod:`cnxdb.contrib.pytest`)
 ------------------------------------
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 # The project's testing dependencies...
+pyramid
 pytest
 pytest-cov
 pytest-mock

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup_requires = (
     'pytest-runner',
     )
 install_requires = (
-    'lxml',
+    'pyramid',
     'psycopg2',
     'sqlalchemy',
     'rhaptos.cnxmlutils',

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -50,7 +50,8 @@ def test_init_without_env_vars(capsys, mocker):
     return_code = main(args)
     assert return_code == 4
 
-    expected_msg = "'DB_URL' environment variable must be defined\n"
+    expected_msg = ("'DB_URL' environment variable "
+                    "OR the 'db.common.url' setting MUST be defined\n")
     assert expected_msg in capsys.readouterr()
 
 
@@ -117,5 +118,6 @@ def test_venv_without_env_vars(capsys, mocker):
     return_code = main(args)
     assert return_code == 4
 
-    expected_msg = "'DB_URL' environment variable must be defined\n"
+    expected_msg = ("'DB_URL' environment variable "
+                    "OR the 'db.common.url' setting MUST be defined\n")
     assert expected_msg in capsys.readouterr()

--- a/tests/contrib/test_pyramid.py
+++ b/tests/contrib/test_pyramid.py
@@ -1,0 +1,40 @@
+import pytest
+from pyramid import testing
+
+from cnxdb.contrib.pyramid import includeme
+
+
+@pytest.fixture
+def pyramid_config():
+    """Preset the discoverable settings, where the pyramid
+    application may want to define these itself, rather than
+    have cnx-db discover them.
+
+    """
+    url = 'sqlite:///:memory:'
+    settings = {
+        'db.common.url': url,
+        'db.super.url': url,
+    }
+    with testing.testConfig(settings=settings) as config:
+        yield config
+
+
+def test_includeme(pyramid_config):
+    includeme(pyramid_config)
+
+
+def test_includeme_with_missing_settings(pyramid_config):
+    pyramid_config.registry.settings = {}
+    with pytest.raises(RuntimeError) as exc_info:
+        includeme(pyramid_config)
+    expected_msg = 'must be defined'
+    assert expected_msg in exc_info.value.args[0].lower()
+
+
+def test_includeme_with_usage(pyramid_config):
+    includeme(pyramid_config)
+
+    assert hasattr(pyramid_config.registry, 'engines')
+    engines = pyramid_config.registry.engines
+    assert sorted(engines.keys()) == ['common', 'super']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,8 @@ from cnxdb.config import discover_settings
 
 
 def test_success(mocker):
-    common_url = 'postgresql://common'
-    super_url = 'postgresql://common'
+    common_url = 'postgresql:///common'
+    super_url = 'postgresql:///common'
 
     _patch = {
         'DB_URL': common_url,
@@ -32,7 +32,7 @@ def test_required(mocker):
 
 
 def test_super_url_not_required(mocker):
-    common_url = 'postgresql://common'
+    common_url = 'postgresql:///common'
 
     _patch = {
         'DB_URL': common_url,
@@ -43,3 +43,22 @@ def test_super_url_not_required(mocker):
 
     assert settings['db.common.url'] == common_url
     assert settings['db.super.url'] == common_url
+
+
+def test_with_existing_settings(mocker):
+    common_url = 'postgresql:///common'
+    other_url = 'oracle:///common'
+
+    _patch = {
+        'DB_URL': other_url,
+        'DB_SUPER_URL': other_url,
+    }
+    mocker.patch.dict(os.environ, _patch)
+    existing_settings = {
+        'db.common.url': common_url
+    }
+
+    settings = discover_settings(existing_settings)
+
+    assert settings['db.common.url'] == common_url
+    assert settings['db.super.url'] == other_url


### PR DESCRIPTION
This adds a contrib module for pyramid integration to be used as `config.include('cnxdb.contrib.pyramid')`.

Depends on #97 