### PR TITLE
Fix the env var test mocking

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -42,7 +42,7 @@ def test_init_called_twice(capsys, db_env_vars):
 
 @pytest.mark.usefixtures('db_wipe')
 def test_init_without_env_vars(capsys, mocker):
-    mocker.patch.dict(os.environ, {})
+    mocker.patch.dict('os.environ', {}, clear=True)
 
     from cnxdb.cli.main import main
     args = ['init']
@@ -110,7 +110,7 @@ def test_venv_called_twice(db_env_vars, db_engines):
 
 @pytest.mark.usefixtures('db_wipe')
 def test_venv_without_env_vars(capsys, mocker):
-    mocker.patch.dict(os.environ, {})
+    mocker.patch.dict('os.environ', {}, clear=True)
 
     from cnxdb.cli.main import main
     args = ['venv']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from cnxdb.config import discover_settings
@@ -13,7 +11,7 @@ def test_success(mocker):
         'DB_URL': common_url,
         'SUPER_URL': super_url,
     }
-    mocker.patch.dict(os.environ, _patch)
+    mocker.patch.dict('os.environ', _patch, clear=True)
 
     settings = discover_settings()
 
@@ -23,7 +21,7 @@ def test_success(mocker):
 
 def test_required(mocker):
     _patch = {}
-    mocker.patch.dict(os.environ, _patch)
+    mocker.patch.dict('os.environ', _patch, clear=True)
 
     with pytest.raises(RuntimeError) as exc_info:
         discover_settings()
@@ -37,7 +35,7 @@ def test_super_url_not_required(mocker):
     _patch = {
         'DB_URL': common_url,
     }
-    mocker.patch.dict(os.environ, _patch)
+    mocker.patch.dict('os.environ', _patch, clear=True)
 
     settings = discover_settings()
 
@@ -53,7 +51,7 @@ def test_with_existing_settings(mocker):
         'DB_URL': other_url,
         'DB_SUPER_URL': other_url,
     }
-    mocker.patch.dict(os.environ, _patch)
+    mocker.patch.dict('os.environ', _patch, clear=True)
     existing_settings = {
         'db.common.url': common_url
     }

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,11 +1,9 @@
-import os
-
 from cnxdb.scripting import prepare
 
 
 def test_prepare(mocker):
     db_url = 'sqlite:///:memory:'
-    mocker.patch.dict(os.environ, {'DB_URL': db_url})
+    mocker.patch.dict('os.environ', {'DB_URL': db_url}, clear=True)
     env = prepare()
 
     assert sorted(env.keys()) == ['closer', 'engines', 'settings']


### PR DESCRIPTION
The bahavior of mock.patch.dict is to mock clone the existing value and overlay with the given dict. I wasn't aware of this cloning behavior when I wrote it.