### PR TITLE
Fix virtualenv importable tests to skip if told

### DIFF
--- a/cnxdb/contrib/pytest.py
+++ b/cnxdb/contrib/pytest.py
@@ -17,6 +17,7 @@ from sqlalchemy import create_engine
 from .testing import (
     get_settings,
     get_database_table_names,
+    is_venv_importable,
 )
 
 
@@ -85,8 +86,7 @@ def db_wipe(db_engines, request, db_cursor_without_db_init):
 def db_init(db_engines):
     """Initializes the database"""
     from cnxdb.init.main import init_db
-    venv = os.getenv('AS_VENV_IMPORTABLE', 'true').lower() == 'true'
-    init_db(db_engines['super'], venv)
+    init_db(db_engines['super'], is_venv_importable())
 
 
 @pytest.fixture

--- a/cnxdb/contrib/testing.py
+++ b/cnxdb/contrib/testing.py
@@ -13,6 +13,7 @@ __all__ = (
     'get_settings',
     'is_py3',
     'is_venv',
+    'is_venv_importable',
 )
 
 
@@ -45,6 +46,22 @@ def is_venv():
 
     """
     return hasattr(sys, 'real_prefix')
+
+
+def is_venv_importable():
+    """Determines whether the tests should be run with virtualenv
+    (aka venv) database import features enabled.
+
+    By default this will be true if the process is running within a venv.
+    This can be overridden by setting the `AS_VENV_IMPORTABLE` environment
+    anything other than the string 'true'.
+
+    :return: enable venv features
+    :rtype: bool
+
+    """
+    x = os.environ.get('AS_VENV_IMPORTABLE', 'true') == 'true'
+    return is_venv() and x
 
 
 def is_py3():

--- a/tests/init/test_main.py
+++ b/tests/init/test_main.py
@@ -37,7 +37,9 @@ def test_db_init_called_twice(db_engines):
         assert False, "the initialization check failed"
 
 
-@pytest.mark.skipif(not testing.is_venv(), reason="not within a venv")
+@pytest.mark.skipif(not testing.is_venv_importable(),
+                    reason=("settings indicate this environment is not "
+                            "virtualenv (venv) importable."))
 @pytest.mark.usefixtures('db_wipe')
 def test_db_init_with_venv(db_engines):
     from cnxdb.init.main import init_db


### PR DESCRIPTION
This is being fixed because one might be in a venv, but not want to connect to the database as virtualenv importable.

This could not make sense, but for my usecase it works. I'm within a venv but running the tests through a container mounted with the local code. The container is not setup to work with a venv, because it doesn't need to be. This change simply brings both scenarios into a compatible use via the existing `AS_VENV_IMPORTABLE` environment variable.