### PR TITLE
Fix various tests to enable use with a container

### DIFF
--- a/cnxdb/contrib/testing.py
+++ b/cnxdb/contrib/testing.py
@@ -54,7 +54,7 @@ def is_venv_importable():
 
     By default this will be true if the process is running within a venv.
     This can be overridden by setting the `AS_VENV_IMPORTABLE` environment
-    anything other than the string 'true'.
+    variable to anything other than the string 'true'.
 
     :return: enable venv features
     :rtype: bool

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,13 @@ setup_requires = (
     'pytest-runner',
     )
 install_requires = (
-    'pyramid',
     'psycopg2',
     'sqlalchemy',
     'rhaptos.cnxmlutils',
     'venusian',
     )
 tests_require = [
+    'pyramid',
     'pytest',
     'pytest-mock',
     ]

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -72,7 +72,9 @@ def assert_venv_is_active(db_engines):
     assert os.path.samefile(db_pyprefix, sys.prefix)
 
 
-@pytest.mark.skipif(not testing.is_venv(), reason="not within a venv")
+@pytest.mark.skipif(not testing.is_venv_importable(),
+                    reason=("settings indicate this environment is not "
+                            "virtualenv (venv) importable."))
 @pytest.mark.usefixtures('db_init_and_wipe')
 def test_venv(db_env_vars, db_engines):
     # Remove the venv schema before trying to initialize it.
@@ -91,7 +93,9 @@ def test_venv(db_env_vars, db_engines):
     assert_venv_is_active(db_engines)
 
 
-@pytest.mark.skipif(not testing.is_venv(), reason="not within a venv")
+@pytest.mark.skipif(not testing.is_venv_importable(),
+                    reason=("settings indicate this environment is not "
+                            "virtualenv (venv) importable."))
 @pytest.mark.usefixtures('db_init_and_wipe')
 def test_venv_called_twice(db_env_vars, db_engines):
     # Note, the initialization already setup the venv,

--- a/tests/contrib/test_pyramid.py
+++ b/tests/contrib/test_pyramid.py
@@ -24,8 +24,10 @@ def test_includeme(pyramid_config):
     includeme(pyramid_config)
 
 
-def test_includeme_with_missing_settings(pyramid_config):
+def test_includeme_with_missing_settings(pyramid_config, mocker):
     pyramid_config.registry.settings = {}
+    mocker.patch.dict('os.environ', {}, clear=True)
+
     with pytest.raises(RuntimeError) as exc_info:
         includeme(pyramid_config)
     expected_msg = 'must be defined'

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py27,py3
 
 [testenv]
+passenv =
+    DB_*
+    AS_VENV_IMPORTABLE
 deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/main.txt


### PR DESCRIPTION
These are fixes to enable the usecase of running the tests against a cnx-db container with the local code mounted into the container.

Please see the extended commit message for information about each commit.

The last commit to remove the 'pyramid' dependency is slipped in. 'pyramid' is not required for this project.