### PR TITLE
Add a read-only database setting and engine

### DIFF
--- a/cnxdb/config.py
+++ b/cnxdb/config.py
@@ -6,6 +6,11 @@ __all__ = ('discover_settings')
 def discover_settings(settings=None):
     """Discover settings from environment variables
 
+    ``DB_URL`` is required, while ``DB_READONLY_URL`` and ``DB_SUPER_URL``
+    are not required and while default to ``DB_URL``. However, be aware
+    that some parts of the application may not function correctly
+    without these optional values set.
+
     :param dict settings: An existing settings value
     :return: dictionary of settings
     :rtype: dict
@@ -20,6 +25,7 @@ def discover_settings(settings=None):
         settings = {}
 
     common_url = os.environ.get('DB_URL', None)
+    readonly_url = os.environ.get('DB_READONLY_URL', common_url)
     super_url = os.environ.get('DB_SUPER_URL', common_url)
 
     if common_url is None and settings.get('db.common.url') is None:
@@ -28,6 +34,7 @@ def discover_settings(settings=None):
 
     new_settings = {
         'db.common.url': common_url,
+        'db.readonly.url': readonly_url,
         'db.super.url': super_url,
     }
 

--- a/cnxdb/scripting.py
+++ b/cnxdb/scripting.py
@@ -20,6 +20,7 @@ def prepare(settings=None):
     settings = discover_settings(settings)
     engines = {
         'common': create_engine(settings['db.common.url']),
+        'readonly': create_engine(settings['db.readonly.url']),
         'super': create_engine(settings['db.super.url']),
     }
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,13 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Add a read-only database setting to allow for read-only database
+  connections. The setting is available through the ``DB_READONLY_URL``
+  environment variable.
+
 1.1.0
 -----
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -11,6 +11,7 @@ The following application settings are mapped to environment variables.
 Setting                          Env Variable            Required?
 ===============================  ======================  =============
 ``db.common.url``                ``DB_URL``              yes
+``db.readonly.url``              ``DB_READONLY_URL``     no
 ``db.super.url``                 ``DB_SUPER_URL``        no
 ===============================  ======================  =============
 

--- a/tests/contrib/test_pyramid.py
+++ b/tests/contrib/test_pyramid.py
@@ -14,6 +14,7 @@ def pyramid_config():
     url = 'sqlite:///:memory:'
     settings = {
         'db.common.url': url,
+        'db.readonly.url': url,
         'db.super.url': url,
     }
     with testing.testConfig(settings=settings) as config:
@@ -39,4 +40,4 @@ def test_includeme_with_usage(pyramid_config):
 
     assert hasattr(pyramid_config.registry, 'engines')
     engines = pyramid_config.registry.engines
-    assert sorted(engines.keys()) == ['common', 'super']
+    assert sorted(engines.keys()) == ['common', 'readonly', 'super']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,17 +5,20 @@ from cnxdb.config import discover_settings
 
 def test_success(mocker):
     common_url = 'postgresql:///common'
-    super_url = 'postgresql:///common'
+    readonly_url = 'postgresql:///readonly'
+    super_url = 'postgresql:///super'
 
     _patch = {
         'DB_URL': common_url,
-        'SUPER_URL': super_url,
+        'DB_READONLY_URL': readonly_url,
+        'DB_SUPER_URL': super_url,
     }
     mocker.patch.dict('os.environ', _patch, clear=True)
 
     settings = discover_settings()
 
     assert settings['db.common.url'] == common_url
+    assert settings['db.readonly.url'] == readonly_url
     assert settings['db.super.url'] == super_url
 
 
@@ -29,7 +32,7 @@ def test_required(mocker):
     assert 'DB_URL' in exc_info.value.args[0]
 
 
-def test_super_url_not_required(mocker):
+def test_other_urls_not_required(mocker):
     common_url = 'postgresql:///common'
 
     _patch = {
@@ -40,6 +43,7 @@ def test_super_url_not_required(mocker):
     settings = discover_settings()
 
     assert settings['db.common.url'] == common_url
+    assert settings['db.readonly.url'] == common_url
     assert settings['db.super.url'] == common_url
 
 
@@ -49,6 +53,7 @@ def test_with_existing_settings(mocker):
 
     _patch = {
         'DB_URL': other_url,
+        'DB_READONLY_URL': other_url,
         'DB_SUPER_URL': other_url,
     }
     mocker.patch.dict('os.environ', _patch, clear=True)
@@ -59,4 +64,5 @@ def test_with_existing_settings(mocker):
     settings = discover_settings(existing_settings)
 
     assert settings['db.common.url'] == common_url
+    assert settings['db.readonly.url'] == other_url
     assert settings['db.super.url'] == other_url

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -7,7 +7,7 @@ def test_prepare(mocker):
     env = prepare()
 
     assert sorted(env.keys()) == ['closer', 'engines', 'settings']
-    assert sorted(env['engines'].keys()) == ['common', 'super']
+    assert sorted(env['engines'].keys()) == ['common', 'readonly', 'super']
     from sqlalchemy.engine import Engine
     assert isinstance(env['engines']['common'], Engine)
 
@@ -24,6 +24,7 @@ def test_prepare(mocker):
 
     expected_settings = {
         'db.common.url': db_url,
+        'db.readonly.url': db_url,
         'db.super.url': db_url,
     }
     assert env['settings'] == expected_settings


### PR DESCRIPTION
This is to be used for operations that only required read access from the database. This means we can configure the application to use the write connections ('common') only when necessary.

We already have a setup that utilizes the replicants for known read-only operations. This now enables the developer to use the correct connection type for the given context.