### PR TITLE
Fix settings discover to use given settings if necessary

### DIFF
--- a/cnxdb/config.py
+++ b/cnxdb/config.py
@@ -24,13 +24,20 @@ def discover_settings(settings=None):
     if settings is None:
         settings = {}
 
+    # Retrieve the required url setting first, so that it can later be used
+    # as the default for the optional urls.
     common_url = os.environ.get('DB_URL', None)
+    if common_url is None:
+        if settings.get('db.common.url') is None:
+            raise RuntimeError("'DB_URL' environment variable "
+                               "OR the 'db.common.url' setting MUST "
+                               "be defined")
+        else:
+            common_url = settings['db.common.url']
+
+    # Set remaining urls, defaulting to the common url when not present.
     readonly_url = os.environ.get('DB_READONLY_URL', common_url)
     super_url = os.environ.get('DB_SUPER_URL', common_url)
-
-    if common_url is None and settings.get('db.common.url') is None:
-        raise RuntimeError("'DB_URL' environment variable "
-                           "OR the 'db.common.url' setting MUST be defined")
 
     new_settings = {
         'db.common.url': common_url,
@@ -38,6 +45,7 @@ def discover_settings(settings=None):
         'db.super.url': super_url,
     }
 
+    # Only amend the existing settings by setting the default.
     for k, v in new_settings.items():
         settings.setdefault(k, v)
     return settings

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ Change Log
 ?.?.?
 -----
 
+- Fix settings discovery to use the given settings value for 'db.common.url'
+  when the ``DB_URL`` environment variable is undefined.
 - Add a read-only database setting to allow for read-only database
   connections. The setting is available through the ``DB_READONLY_URL``
   environment variable.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,3 +66,18 @@ def test_with_existing_settings(mocker):
     assert settings['db.common.url'] == common_url
     assert settings['db.readonly.url'] == other_url
     assert settings['db.super.url'] == other_url
+
+
+def test_with_existing_settings_and_no_env(mocker):
+    common_url = 'postgresql:///common'
+
+    mocker.patch.dict('os.environ', {}, clear=True)
+    existing_settings = {
+        'db.common.url': common_url
+    }
+
+    settings = discover_settings(existing_settings)
+
+    assert settings['db.common.url'] == common_url
+    assert settings['db.readonly.url'] == common_url
+    assert settings['db.super.url'] == common_url


### PR DESCRIPTION
This fixes an issue when a set of settings is given and the env vars are not set. This ensure that we use the given value for the `db.common.url` setting in place of the missing DB_URL rather than leave it `None`, which would set the defaults for the other urls to `None` as well.