### PR TITLE
Add a tables spec lookup to the pyramid contrib module

### DIFF
--- a/cnxdb/contrib/pyramid.py
+++ b/cnxdb/contrib/pyramid.py
@@ -5,18 +5,43 @@ When used in conjunction with the `Pyramid Web Framework
 this module will setup the cnx-db library within the Pyramid application.
 
 """
+from sqlalchemy import MetaData
+
 from cnxdb.scripting import prepare
 
 
-__all__ = ('includeme',)
+__all__ = ('includeme', 'meta',)
+
+
+meta = MetaData()
+
+
+class _Tables(object):
+
+    metadata = None
+
+    def __init__(self, metadata=meta):
+        self.metadata = metadata
+
+    def __getattr__(self, name):
+        return self.metadata.tables[name]
 
 
 def includeme(config):
     """Used by pyramid to include this package.
 
-    This sets up a dictionary of engines for use.
-    They can be retrieved via the registry at ``registry.engines``.
+    This sets up a dictionary of engines for use
+    and the a ``tables`` object
+    containing the defined database tables
+    as sqlalchemy ``Table`` objects.
+    They can be retrieved via the registry
+    at ``registry.engines`` and ``registry.tables``.
 
     """
     env = prepare(config.registry.settings)
-    config.registry.engines = env['engines']
+    engines = env['engines']
+    # Set the engines on the registry
+    config.registry.engines = engines
+    # Initialize the tables on the registry
+    config.registry.tables = _Tables()
+    config.registry.tables.metadata.reflect(bind=engines['common'])

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,14 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Add a database tables definition to the pyramid integration.
+  This places a ``tables`` attribute on the registry.
+  The attribute contains sqlalchemy table definitions that are reflected
+  from the existing database schema.
+
 1.2.0
 -----
 


### PR DESCRIPTION
This gives the pyramid application access to the sqlalchemy reflected tables, which can then be used in conjunction with sqlalchemy core features.