### PR TITLE
Recreate connection pool after init_venv in tests

### DIFF
--- a/cnxdb/contrib/pytest.py
+++ b/cnxdb/contrib/pytest.py
@@ -87,6 +87,11 @@ def db_init(db_engines):
     """Initializes the database"""
     from cnxdb.init.main import init_db
     init_db(db_engines['super'], is_venv_importable())
+    if is_venv_importable():
+        # We need to recreate the connection pool after initializing venv
+        # because all the existing connections wouldn't have venv set up
+        for engine in db_engines.values():
+            engine.dispose()
 
 
 @pytest.fixture


### PR DESCRIPTION
We use sqlalchemy to initialize our database, that includes setting a
function that is run at the beginning of every session (what init_venv
does).  But sqlalchemy engines have connection pools that are already
connected, so virtualenv is not set up correctly for those connections,
causing the triggers to not be able to find the cnx code.