### PR TITLE
migration for fixing primary key on print_style_recipe table

### DIFF
--- a/cnxdb/migrations/20171130213038_recipe-primary-key.py
+++ b/cnxdb/migrations/20171130213038_recipe-primary-key.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
+def up(cursor):
+    cursor.execute("""
+    alter table print_style_recipes drop constraint print_style_recipes_pkey ;
+    alter table print_style_recipes add constraint print_style_recipes_pkey
+        PRIMARY KEY (print_style, tag);
+    """)
+
+
+def down(cursor):
+    cursor.execute("""
+    alter table print_style_recipes drop constraint print_style_recipes_pkey ;
+    alter table print_style_recipes add constraint print_style_recipes_pkey
+        PRIMARY KEY (print_style);
+    """)


### PR DESCRIPTION
This will not pass migration test - rollback is to the actual current broken state, not to what cnx-db-init gives. Original code and migration predated the migration tests.