### PR TITLE
Add module level testing fixtures to better facilitate testing in dependent packages

### DIFF
--- a/cnxdb/contrib/pytest.py
+++ b/cnxdb/contrib/pytest.py
@@ -46,11 +46,10 @@ def db_engines(db_settings):
 @pytest.fixture
 def db_env_vars(mocker, db_settings):
     """Sets the environment variables used by this project"""
-    env_vars = os.environ.copy()
-    env_vars.update({
+    env_vars = {
         'DB_URL': db_settings['db.common.url'],
         'DB_SUPER_URL': db_settings['db.super.url'],
-    })
+    }
     mocker.patch.dict(os.environ, env_vars)
     yield env_vars
     pass

--- a/cnxdb/contrib/pytest.py
+++ b/cnxdb/contrib/pytest.py
@@ -160,3 +160,13 @@ def db_dict_cursor(db_engines, db_settings):
     yield cursor
     cursor.close()
     conn.close()
+
+
+@pytest.fixture
+def db_tables(db_engines):
+    """Provides access to sqlalchemy table objects"""
+    # FIXME put the Tables class in a more common location.
+    from .pyramid import _Tables
+    tables = _Tables()
+    tables.metadata.reflect(bind=db_engines['common'])
+    return tables

--- a/cnxdb/contrib/pytest.py
+++ b/cnxdb/contrib/pytest.py
@@ -191,3 +191,9 @@ def db_tables(db_engines):
     tables = _Tables()
     tables.metadata.reflect(bind=db_engines['common'])
     return tables
+
+
+@pytest.fixture(scope='module')
+def db_tables_module_scope(db_engines):
+    """Provides access to sqlalchemy table objects"""
+    return db_tables(db_engines)

--- a/cnxdb/contrib/testing.py
+++ b/cnxdb/contrib/testing.py
@@ -9,7 +9,6 @@ import sys
 
 
 __all__ = (
-    'get_database_table_names',
     'get_settings',
     'is_py3',
     'is_venv',
@@ -71,24 +70,3 @@ def is_py3():
 
     """
     return sys.version_info > (3,)
-
-
-def _default_table_name_filter(table_name):
-    return (not table_name.startswith('pg_') and
-            not table_name.startswith('_pg_'))
-
-
-def get_database_table_names(cursor,
-                             table_name_filter=_default_table_name_filter):
-    """Query for the names of all the tables in the database.
-
-    :return: tables names
-    :rtype: list
-
-    """
-    cursor.execute("SELECT table_name "
-                   "FROM information_schema.tables "
-                   "ORDER BY table_name")
-    tables = [table_name for (table_name,) in cursor.fetchall()
-              if table_name_filter(table_name)]
-    return list(tables)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,17 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Massage testing fixtures to better facilitate testing in packages using
+  this package.
+
+  - Provide additional init and wipe fixtures scoped at the module level.
+  - Remove custom function for table name lookup. Replaced by sqlalchemy
+    Inspector methods.
+  - Add a ``db_tables`` pytest fixture that supplies sqlalchemy table objects.
+
 1.3.0
 -----
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,24 +3,21 @@ import os
 import sys
 
 import pytest
+from sqlalchemy.engine.reflection import Inspector
 
 from cnxdb.contrib import testing
 
 
 @pytest.mark.usefixtures('db_wipe')
-def test_init(db_env_vars, db_cursor_without_db_init):
+def test_init(db_env_vars, db_engines):
     from cnxdb.cli.main import main
     args = ['init']
     return_code = main(args)
 
     assert return_code == 0
 
-    def table_name_filter(table_name):
-        return (not table_name.startswith('pg_') and
-                not table_name.startswith('_pg_'))
-
-    cursor = db_cursor_without_db_init
-    tables = testing.get_database_table_names(cursor, table_name_filter)
+    inspector = Inspector.from_engine(db_engines['common'])
+    tables = inspector.get_table_names()
 
     assert 'modules' in tables
     assert 'pending_documents' in tables


### PR DESCRIPTION
- Massage testing fixtures to better facilitate testing in packages using
  this package.

  - Provide additional init and wipe fixtures scoped at the module level.
  - Remove custom function for table name lookup. Replaced by sqlalchemy
    Inspector methods.
  - Add a ``db_tables`` pytest fixture that supplies sqlalchemy table objects.