### PR TITLE
add baked to get-module-metadata

### DIFF
--- a/cnxdb/archive-sql/get-module-metadata.sql
+++ b/cnxdb/archive-sql/get-module-metadata.sql
@@ -107,7 +107,8 @@ FROM (SELECT
       WHERE mf.module_ident = m.module_ident
       ORDER BY f.sha1, f.media_type, mf.filename
     ) AS module_file_row) AS resources,
-  m.print_style AS "printStyle"
+  m.print_style AS "printStyle",
+  m.baked AS "baked"
 FROM modules m
   LEFT JOIN abstracts a on m.abstractid = a.abstractid
   LEFT JOIN modules p on m.parent = p.module_ident,

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,11 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Add the baked and print-style columns to the module metadata query.
+
 1.4.0
 -----
 


### PR DESCRIPTION
Adding the baked status to the return for get-module-metadata. The baked status is used in determining whether or not to cache in cnx-archive.

Connected to: https://github.com/Connexions/cnx-archive/pull/542