### PR TITLE
Fix the empty container story

### DIFF
--- a/.dockerfiles/initdb.d/00_initdb.sh
+++ b/.dockerfiles/initdb.d/00_initdb.sh
@@ -12,7 +12,7 @@ psql -v ON_ERROR_STOP=1 --username postgres <<-EOSQL
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA PUBLIC TO ${DB_USER};
 EOSQL
 
-if [ -z "`ls *.sql.gz`" -a -z  "`ls *.sql`" ]; then
+if [ -z "`ls /docker-entrypoint-initdb.d/*.sql.gz`" -a -z  "`ls /docker-entrypoint-initdb.d/*.sql`" ]; then
     cnx-db init
 fi
 

--- a/.dockerfiles/initdb.d/00_initdb.sh
+++ b/.dockerfiles/initdb.d/00_initdb.sh
@@ -4,10 +4,10 @@ set -e
 psql -v ON_ERROR_STOP=1 --username postgres <<-EOSQL
     CREATE USER ${DB_USER};
     CREATE USER backups;
-    ALTER DATABASE "${DB_NAME}" OWNER TO ${DB_USER};
-    GRANT ALL PRIVILEGES ON DATABASE "${DB_NAME}" TO ${POSTGRES_USER};
-    GRANT ALL PRIVILEGES ON DATABASE "${DB_NAME}" TO ${DB_USER};
-    \c "${DB_NAME}" ${POSTGRES_USER}
+    ALTER DATABASE "${POSTGRES_DB}" OWNER TO ${DB_USER};
+    GRANT ALL PRIVILEGES ON DATABASE "${POSTGRES_DB}" TO ${POSTGRES_USER};
+    GRANT ALL PRIVILEGES ON DATABASE "${POSTGRES_DB}" TO ${DB_USER};
+    \c "${POSTGRES_DB}" ${POSTGRES_USER}
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA PUBLIC TO ${POSTGRES_USER};
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA PUBLIC TO ${DB_USER};
 EOSQL
@@ -17,6 +17,6 @@ if [ -z "`ls /docker-entrypoint-initdb.d/*.sql.gz`" -a -z  "`ls /docker-entrypoi
 fi
 
 # ??? Is this really what we want to be doing?
-psql -v ON_ERROR_STOP=1 --username postgres "$DB_NAME" <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username postgres "$POSTGRES_DB" <<-EOSQL
     REASSIGN OWNED BY ${POSTGRES_USER} TO ${DB_USER};
 EOSQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,16 @@ RUN set -x \
 
 EXPOSE 5432
 
+# This is a specially created user for non-superuser operations.
 ENV DB_USER=rhaptos
-ENV DB_NAME=repository
 
+# We use the 'rhaptos_admin' user for superuser operations.
 ENV POSTGRES_USER=rhaptos_admin
+ENV POSTGRES_DB=repository
+
+# These are used by this codebase's tools (e.g. `cnxdb init`).
+ENV DB_URL=postgresql://rhaptos@localhost/repository
+ENV DB_SUPER_URL=postgresql://postgres@localhost/repository
 
 # This is a hook into the postgres:* container to do database init
 COPY .dockerfiles/initdb.d/* /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,6 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - DB_USER=rhaptos
-      - DB_NAME=repository
-      - POSTGRES_DB=repository
       - DB_URL=postgresql://rhaptos@localhost/repository
       - DB_SUPER_URL=postgresql://postgres@localhost/repository
 volumes:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,13 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Fix .dockerfiles/initdb.d/00_initdb.sh to look for ``*.sql``
+  and ``*.sql.gz`` files in the docker entrypoint directory rather than
+  the current working directory.
+
 1.5.0
 -----
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ Change Log
 ?.?.?
 -----
 
+- Remove the ``DB_NAME`` environment variable from the container definition.
+  This appears to have become redundant with the ``POSTGRES_DB`` variable.
 - Fix .dockerfiles/initdb.d/00_initdb.sh to look for ``*.sql``
   and ``*.sql.gz`` files in the docker entrypoint directory rather than
   the current working directory.


### PR DESCRIPTION
These are fixes to address starting an empty cnx-db container. We added the feature to consume a slim dump, which works great, but missed the creation of a vanilla database.

I'm kind of surprised the tests didn't catch this, but I do believe as we move more tests into this package that will be covered.

The first commit addresses the issue with the condition to run `cnxdb init`. The second removes what I believe is now a redundant setting.