### PR TITLE
Fix collxml shredder to insert trees.lastest value

### DIFF
--- a/cnxdb/migrations/20180408175622_amend_shred_collxml_to_insert_latest_column_value.py
+++ b/cnxdb/migrations/20180408175622_amend_shred_collxml_to_insert_latest_column_value.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import os
+from contextlib import contextmanager
+
+from dbmigrator import super_user
+
+
+@contextmanager
+def open_here(filepath, *args, **kwargs):
+    """open a file relative to this files location"""
+    here = os.path.abspath(os.path.dirname(__file__))
+    fp = open(os.path.join(here, filepath), *args, **kwargs)
+    yield fp
+    fp.close()
+
+
+def up(cursor):
+    with super_user() as super_cursor:
+        with open_here('../archive-sql/schema/shred_collxml.sql', 'rb') as f:
+            super_cursor.execute(f.read())
+
+
+def down(cursor):
+    with super_user() as super_cursor:
+        with open_here('shred_collxml_20180408175622_pre.sql', 'rb') as f:
+            super_cursor.execute(f.read())

--- a/cnxdb/migrations/20180408181936_make_everything_republishable.py
+++ b/cnxdb/migrations/20180408181936_make_everything_republishable.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    # Do a blanket set to make sure everything has the ``trees.latest``
+    # column set. This value should be True for all legacy content.
+    cursor.execute("UPDATE trees SET latest = true")
+
+
+def down(cursor):
+    # No need for a rollback migration
+    pass

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,14 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Fix shred_collxml code to insert the ``trees.latest`` value.
+  The fix includes a migration to ensure all ``trees.latest`` values are
+  set to true, which should be the casee for all legacy content.
+  See https://github.com/Connexions/cnx-db/issues/120 for issue details.
+
 1.6.0
 -----
 


### PR DESCRIPTION
This fixes the collxml shredder to insert a value for ``trees.latest``. This also contains a migration to set all the current records to ``trees.latest = true``.

Fixes #120 