### PR TITLE
Fix requirements file with editable flag for vcs requirements

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,9 +5,9 @@ pytest-cov
 pytest-mock
 mock==1.0.1;python_version<="2.7"
 
-git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
-git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
-git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
-git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
+-e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
+-e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
+-e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
+-e git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
 # FIXME circular dependency here...
-git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
+-e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive


### PR DESCRIPTION
The release of ``pip==10.0.0`` changed some behavior with our requirements.txt files. In this case the fault is on us and partially on the new release. The requirements lines that point at git repos aren't prefixed with `-e`, which makes them editable installs and thus reinstallable. The new release is at fault for raising an error rather than saying something to the effect of "the requirement is satisfied and won't upgrade."

See pypa/pip#5251