### PR TITLE
Rename api points for Pyramid contrib module

### DIFF
--- a/cnxdb/contrib/testing.py
+++ b/cnxdb/contrib/testing.py
@@ -32,6 +32,7 @@ def get_settings():
 
     settings = {
         'db.common.url': common_url,
+        'db.readonly.url': common_url,
         'db.super.url': super_url,
     }
     return settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - ./docs:/src/docs:z
       - ./cnxdb:/src/cnxdb:z
       - ./htmlcov:/src/htmlcov:z
+      - ./.dockerfiles/initdb.d/:/docker-entrypoint-initdb.d/:z
       - pg-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,15 @@ Change Log
 
    - feature message
 
+?.?.?
+-----
+
+- Transition the following Pyramid integration properties:
+  ``registry.engines`` and ``registry.tables``. These are now moved to
+  ``request.get_db_engine()`` and ``request.db_tables()``.
+  This favors the recommended pattern of using request methods
+  for hooking into the current thread local variable space.
+
 1.6.1
 -----
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,8 +87,14 @@ using the imperative configuration style:
        # ...
        return config.make_wsgi_app()
 
-This will give you access to the ``engines`` and ``tables`` attributes
-on the registry.
-The ``engines`` attribute is a dictionary of SQLAlchemy Engine objects.
-The ``tables`` object contains references SQLAlchemy Table objects
-that have been created from the database through inspection.
+This will give you access to the ``get_db_engine`` and ``db_tables``
+methods on the request object.
+
+The ``get_db_engine`` method returns a SQLAlchemy Engine object.
+It can optionally be given a connection name
+(``common``, ``super``, ``readonly``).
+If the connection name is ommited, it will default to the use of ``common``.
+
+The ``db_tables`` methods returns an object contains references
+SQLAlchemy Table objects that have been created from the database
+through SQLAlchemy's inspection process.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 # The project's testing dependencies...
+pretend
 pyramid
 pytest
 pytest-cov

--- a/tests/contrib/test_pyramid.py
+++ b/tests/contrib/test_pyramid.py
@@ -1,8 +1,42 @@
+from collections import OrderedDict
+
+import pretend
 import psycopg2
 import pytest
 from pyramid import testing
+from sqlalchemy.engine import Engine
+from zope.interface.interfaces import ComponentLookupError
 
-from cnxdb.contrib.pyramid import includeme
+from cnxdb.contrib.pyramid import (
+    _Tables,
+    db_tables,
+    get_db_engine,
+    includeme,
+    IEngine,
+    ITables,
+)
+
+
+# Allow pretend's call_recorder to check by instance
+# See also https://github.com/alex/pretend/issues/7
+class _InstanceOf:
+    """Allow pretend's call_recorder equality test
+    to check for instance equality rather than value/identity.
+
+    """
+
+    def __init__(self, type_):
+        self._type = type_
+
+    def __eq__(self, other):
+        return isinstance(other, self._type)
+
+    def __ne__(self, other):
+        return not isinstance(other, self._type)
+
+
+def instance_of(type_):
+    return _InstanceOf(type_)
 
 
 @pytest.fixture
@@ -16,8 +50,36 @@ def pyramid_config(db_settings):
         yield config
 
 
-def test_includeme(pyramid_config):
-    includeme(pyramid_config)
+def test_includeme(db_settings, db_engines, monkeypatch):
+    env = {'engines': OrderedDict(db_engines)}
+    prepare = pretend.call_recorder(lambda s: env)
+    monkeypatch.setattr('cnxdb.contrib.pyramid.prepare', prepare)
+
+    registerUtility = pretend.call_recorder(lambda *a, **kw: None)
+    registry = pretend.stub(
+        registerUtility=registerUtility,
+        settings=db_settings,
+    )
+    add_request_method = pretend.call_recorder(lambda *a, **kw: None)
+    config = pretend.stub(
+        add_request_method=add_request_method,
+        registry=registry,
+    )
+
+    includeme(config)
+
+    expected_calls = [pretend.call(instance_of(_Tables), ITables)]
+    expected_calls.extend([
+        pretend.call(engine, IEngine, name=name)
+        for name, engine in env['engines'].items()
+    ])
+    expected_calls.append(pretend.call(instance_of(Engine), IEngine))
+    assert registerUtility.calls == expected_calls
+
+    assert add_request_method.calls == [
+        pretend.call(get_db_engine),
+        pretend.call(db_tables, reify=True),
+    ]
 
 
 def test_includeme_with_missing_settings(pyramid_config, mocker):
@@ -30,9 +92,9 @@ def test_includeme_with_missing_settings(pyramid_config, mocker):
     assert expected_msg in exc_info.value.args[0].lower()
 
 
-def test_includeme_with_usage(pyramid_config, db_wipe):
+def test_includeme_with_usage(db_settings, db_wipe):
     # Initialize a table to ensure table reflection is working.
-    conn_str = pyramid_config.registry.settings['db.common.url']
+    conn_str = db_settings['db.common.url']
     with psycopg2.connect(conn_str) as conn:
         with conn.cursor() as cur:
             cur.execute("CREATE TABLE smurfs ("
@@ -42,11 +104,24 @@ def test_includeme_with_usage(pyramid_config, db_wipe):
         conn.commit()
 
     # Call the target function
-    includeme(pyramid_config)
+    request = testing.DummyRequest()
+    with testing.testConfig(request=request, settings=db_settings) as config:
+        includeme(config)
 
-    # Check the engines definition
-    assert hasattr(pyramid_config.registry, 'engines')
-    engines = pyramid_config.registry.engines
-    assert sorted(engines.keys()) == ['common', 'readonly', 'super']
-    # Check the tables definition
-    assert hasattr(pyramid_config.registry.tables, 'smurfs')
+        # The request doesn't yet have the added methods and I'm not sure
+        # how to make the test request have those, so we'll call them
+        # directly instead. We aren't testing the framework's
+        # add_request_method anyhow.
+
+        # Check the engines definitions
+        # ... looking for the unnamed util lookup
+        assert str(get_db_engine(request).url) == db_settings['db.common.url']
+        # ... looking for the named util lookup
+        expected_url = db_settings['db.readonly.url']
+        assert str(get_db_engine(request, 'readonly').url) == expected_url
+
+        with pytest.raises(ComponentLookupError):
+            get_db_engine(request, 'foobar')
+
+        # Check the tables definition
+        assert hasattr(db_tables(request), 'smurfs')


### PR DESCRIPTION
Transition the following Pyramid integration properties:
``registry.engines`` and ``registry.tables``. These are now moved to
``request.get_db_engine()`` and ``request.db_tables()``.
This favors the recommended pattern of using request methods
for hooking into the current thread local variable space.