### PR TITLE
Ignore env build state and python dist and build directories in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+./.state
+./dist
+./build

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 /*.log
 .cache
 .state
+.pytest_cache
 
 # Build file #
 ##############


### PR DESCRIPTION
Just adds a ``.dockerignore`` file similar to ``.gitignore``.