### PR TITLE
Correct the documentation to align with the implementation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,13 +9,18 @@ Change Log
 
    - feature message
 
+?.?.X
+-----
+
+- Fix the documentation for Pyramid integration properties.
+
 2.0.0
 -----
 
 - Transition the following Pyramid integration properties:
   ``registry.engines`` and ``registry.tables``. These are now moved to
-  ``request.get_db_engine()`` and ``request.db_tables()``.
-  This favors the recommended pattern of using request methods
+  ``request.get_db_engine()`` and ``request.db_tables``.
+  This favors the recommended pattern of using request methods and attributes
   for hooking into the current thread local variable space.
 
 1.6.1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -88,13 +88,13 @@ using the imperative configuration style:
        return config.make_wsgi_app()
 
 This will give you access to the ``get_db_engine`` and ``db_tables``
-methods on the request object.
+method and attribute on the request object.
 
 The ``get_db_engine`` method returns a SQLAlchemy Engine object.
 It can optionally be given a connection name
 (``common``, ``super``, ``readonly``).
 If the connection name is ommited, it will default to the use of ``common``.
 
-The ``db_tables`` methods returns an object contains references
+The ``db_tables`` attribute returns an object contains references
 SQLAlchemy Table objects that have been created from the database
 through SQLAlchemy's inspection process.


### PR DESCRIPTION
This simply aligns the pyramid integration docs with the implementation.