### PR TITLE
Do not strip the first part of resource name if it contains a module id

### DIFF
--- a/cnxdb/triggers/transforms/resolvers.py
+++ b/cnxdb/triggers/transforms/resolvers.py
@@ -29,7 +29,7 @@ if sys.version_info > (3,):
 
 
 LEGACY_PATH_REFERENCE_REGEX = re.compile(
-r"""^
+    r"""^
 (?:
   (https?://cnx.org)
   |
@@ -43,8 +43,9 @@ r"""^
     (m|col)
     \d{4,5}
   )
+  (?![^/@\#?])  # negative lookahead to see if this is a url or filename
   (
-    [/@]
+    [/@]  # / or @ (note, @ is put in by xslt for 'link' tags)
     (?P<version>
       (
         [.\d]+

--- a/cnxdb/triggers/transforms/resolvers.py
+++ b/cnxdb/triggers/transforms/resolvers.py
@@ -29,14 +29,56 @@ if sys.version_info > (3,):
 
 
 LEGACY_PATH_REFERENCE_REGEX = re.compile(
-    r'^(?:(https?://cnx.org)|(?P<legacy>https?://legacy.cnx.org))?'
-    r'(/?(content/)? *'
-    r'(?P<module>(m|col)\d{4,5})([/@](?P<version>([.\d]+|latest)))?)?/?'
-    r'(?P<resource>[^#?][ -_.@\w\d]+)?'
-    r'(?:\?collection=(?P<collection>(col\d{4,5}))'
-    r'(?:[/@](?P<collection_version>([.\d]+|latest)))?)?'
-    r'(?P<fragment>#?.*)?$',
-    re.IGNORECASE)
+r"""^
+(?:
+  (https?://cnx.org)
+  |
+  (?P<legacy>https?://legacy.cnx.org)
+)?
+(
+  /?
+  (content/)?
+  [ ]*
+  (?P<module>
+    (m|col)
+    \d{4,5}
+  )
+  (
+    [/@]
+    (?P<version>
+      (
+        [.\d]+
+        |
+        latest
+      )
+    )
+  )?
+)?
+/?
+(?P<resource>
+  [^\#?]
+  [ -_.@\w\d]+
+)?
+(?:
+  \?
+  collection=
+  (?P<collection>
+    (col\d{4,5})
+  )
+  (?:
+    [/@]
+    (?P<collection_version>
+      (
+        [.\d]+
+        |
+        latest
+      )
+    )
+  )?
+)?
+(?P<fragment>\#?.*)?
+$""",
+    re.IGNORECASE | re.VERBOSE)
 PATH_REFERENCE_REGEX = re.compile(r"""
 ^(?:
   (https?://cnx.org)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ Change Log
 -----
 
 - Fix the documentation for Pyramid integration properties.
+- Fix the HTML reference resolver for cases where the moduleid is found
+  in the resource filename.
 
 2.0.0
 -----

--- a/tests/triggers/transforms/test_resolvers.py
+++ b/tests/triggers/transforms/test_resolvers.py
@@ -244,15 +244,23 @@ class TestHtmlReferenceResolution(BaseTestCase):
         # m19809 "Gavin Bakers entry..."
         expected = (MODULE_REFERENCE, ('m19770', None, None, None, ''))
         assert parse_reference('/ m19770') == expected
+        assert parse_reference(' m19770') == expected
 
         # m16562 "Flat Stanley.pdf"
         expected = (RESOURCE_REFERENCE, ('Flat Stanley.pdf', None, None))
         assert parse_reference(' Flat Stanley.pdf') == expected
 
+        # a17dd5c3-3b8c-4fd5-b814-e78bc5a30917@1.html
+        expected = (RESOURCE_REFERENCE, ('m16020_DotPlot_description.html',
+                                         None, None))
+        assert parse_reference('/m16020_DotPlot_description.html') == expected
+        assert parse_reference('m16020_DotPlot_description.html') == expected
+
         # m34830 "Auto_fatalities_data.xls"
         expected = (RESOURCE_REFERENCE,
                     ('Auto_fatalities_data.xls', None, None))
         assert parse_reference('/Auto_fatalities_data.xls') == expected
+        assert parse_reference('Auto_fatalities_data.xls') == expected
 
         # m35999 "version 2.3 of the first module"
         expected = (MODULE_REFERENCE, ('m0000', '2.3', None, None, ''))


### PR DESCRIPTION
This corrects the issue (that wasn't created as an issue 😠) with where resource files with filenames that start with the module id were being stripped of the moduleid text. This happened because the reference path regex matches for all references not just resources.

The fix is to lookahead for url like markers. If the reference doesn't contain those markers we can assume it's a resource filename.

The first commit makes the existing regex pretty and verbose. The second commit actually fixes the issue.