### PR TITLE
Add indices and modify a trigger

### DIFF
--- a/cnxdb/archive-sql/schema/fulltext-indexing.sql
+++ b/cnxdb/archive-sql/schema/fulltext-indexing.sql
@@ -133,11 +133,9 @@ CREATE OR REPLACE FUNCTION index_collated_fulltext_trigger()
     has_existing_record integer;
     _baretext text;
     _idx_vectors tsvector;
-
   BEGIN
     has_existing_record := (SELECT item FROM collated_fti WHERE item = NEW.item and context = NEW.context);
     _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text FROM files AS f WHERE f.fileid = NEW.fileid);
-
     _idx_vectors := to_tsvector(_baretext);
 
     IF has_existing_record IS NULL THEN

--- a/cnxdb/archive-sql/schema/fulltext-indexing.sql
+++ b/cnxdb/archive-sql/schema/fulltext-indexing.sql
@@ -157,13 +157,13 @@ CREATE TRIGGER index_collated_fulltext
   AFTER INSERT OR UPDATE ON collated_file_associations
     FOR EACH row
       EXECUTE PROCEDURE index_collated_fulltext_trigger();
---
--- CREATE AGGREGATE tsvector_agg (
---       BASETYPE = tsvector,
---       SFUNC = tsvector_concat,
---       STYPE = tsvector,
---       INITCOND = ''
---     );
+
+CREATE AGGREGATE tsvector_agg (
+  BASETYPE = tsvector,
+  SFUNC = tsvector_concat,
+  STYPE = tsvector,
+  INITCOND = ''
+);
 
 CREATE OR REPLACE FUNCTION insert_book_fti(bookid integer)
   RETURNS void

--- a/cnxdb/archive-sql/schema/fulltext-indexing.sql
+++ b/cnxdb/archive-sql/schema/fulltext-indexing.sql
@@ -62,29 +62,38 @@ CREATE OR REPLACE FUNCTION index_fulltext_trigger()
     _baretext text;
     _keyword text;
     _title text;
+    _abstract text;
     _idx_text_vectors tsvector;
     _idx_title_vectors tsvector;
     _idx_keyword_vectors tsvector;
+    _idx_abstract_vectors tsvector;
 
   BEGIN
     has_existing_record := (SELECT module_ident FROM modulefti WHERE module_ident = NEW.module_ident);
     _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text
                     FROM files AS f WHERE f.fileid = NEW.fileid);
-    _keyword := (SELECT k.word FROM keywords k INNER JOIN modulekeywords m
+    _keyword := (SELECT LIST(k.word) FROM keywords k INNER JOIN modulekeywords m
                    ON k.keywordid = m.keywordid
-                    AND m.module_ident = NEW.module_ident);
+                    WHERE m.module_ident = NEW.module_ident);
     _title := (SELECT modules.name FROM modules WHERE module_ident = NEW.module_ident);
+    _abstract := (SELECT ab.abstract FROM abstracts ab INNER JOIN modules m
+                   ON ab.abstractid = m.abstractid
+                    WHERE m.module_ident = NEW.module_ident);
     _idx_title_vectors := setweight(to_tsvector(COALESCE(_title, '')), 'A');
     _idx_keyword_vectors := setweight(to_tsvector(COALESCE(_keyword, '')), 'B');
+    _idx_abstract_vectors := setweight(to_tsvector(COALESCE(_abstract, '')), 'B');
     _idx_text_vectors := setweight(to_tsvector(COALESCE(_baretext, '')), 'C');
+
 
     IF has_existing_record IS NULL THEN
       INSERT INTO modulefti (module_ident, fulltext, module_idx)
-        VALUES ( NEW.module_ident, _baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors);
+        VALUES ( NEW.module_ident, _baretext, _idx_title_vectors || _idx_keyword_vectors
+                 || _idx_abstract_vectors || _idx_text_vectors);
 
     ELSE
       UPDATE modulefti
-        SET (fulltext, module_idx) = (_baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors)
+        SET (fulltext, module_idx) = (_baretext, _idx_title_vectors || _idx_keyword_vectors
+             || _idx_abstract_vectors || _idx_text_vectors)
           WHERE module_ident = NEW.module_ident;
     END IF;
     RETURN NEW;

--- a/cnxdb/archive-sql/schema/functions.sql
+++ b/cnxdb/archive-sql/schema/functions.sql
@@ -198,6 +198,12 @@ CREATE OR REPLACE FUNCTION short_ident_hash(uuid uuid, major integer, minor inte
  IMMUTABLE
 AS $function$ select short_id(uuid) || '@' || concat_ws('.', major, minor) $function$;
 
+CREATE FUNCTION year(ts timestamptz)
+  RETURNS DOUBLE PRECISION IMMUTABLE
+  AS $$
+  SELECT EXTRACT(year from ts)
+  $$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION plainto_or_tsquery (TEXT) RETURNS tsquery AS $$
   SELECT to_tsquery( regexp_replace( $1, E'[\\s\'|:&()!]+','|','g') );
 $$ LANGUAGE SQL STRICT IMMUTABLE;
@@ -227,4 +233,6 @@ CREATE AGGREGATE LAST (
         basetype = anyelement,
         stype    = anyelement
 );
+
+
 

--- a/cnxdb/archive-sql/schema/indexes.sql
+++ b/cnxdb/archive-sql/schema/indexes.sql
@@ -14,6 +14,8 @@ CREATE INDEX latest_modules_upname_idx ON latest_modules  (upper(name));
 CREATE INDEX latest_modules_moduleid_idx on latest_modules (moduleid);
 CREATE INDEX latest_modules_module_ident_idx on latest_modules (module_ident);
 CREATE INDEX latest_modules_portal_type_idx on latest_modules (portal_type);
+CREATE INDEX latest_modules_gin_authors_idx on latest_modules gin(authors);
+CREATE INDEX latest_modules_publication_year_idx on latest_modules (year(revised));
 CREATE UNIQUE INDEX lastest_modules_uuid_idx on latest_modules (uuid);
 CREATE INDEX latest_modules_uuid_text_version_idx on
     latest_modules (cast(uuid as text), module_version(major_version, minor_version));

--- a/cnxdb/archive-sql/schema/indexes.sql
+++ b/cnxdb/archive-sql/schema/indexes.sql
@@ -14,7 +14,7 @@ CREATE INDEX latest_modules_upname_idx ON latest_modules  (upper(name));
 CREATE INDEX latest_modules_moduleid_idx on latest_modules (moduleid);
 CREATE INDEX latest_modules_module_ident_idx on latest_modules (module_ident);
 CREATE INDEX latest_modules_portal_type_idx on latest_modules (portal_type);
-CREATE INDEX latest_modules_gin_authors_idx on latest_modules gin(authors);
+CREATE INDEX latest_modules_gin_authors_idx on latest_modules using gin(authors);
 CREATE INDEX latest_modules_publication_year_idx on latest_modules (year(revised));
 CREATE UNIQUE INDEX lastest_modules_uuid_idx on latest_modules (uuid);
 CREATE INDEX latest_modules_uuid_text_version_idx on

--- a/cnxdb/archive-sql/search/quick-wrapper.sql
+++ b/cnxdb/archive-sql/search/quick-wrapper.sql
@@ -1,0 +1,110 @@
+-- arguments text_terms:string "%(text_terms)s"
+SELECT row_to_json(combined_rows) as results
+FROM (
+WITH weighted_query_results AS (
+  SELECT
+
+  cm.module_ident,
+
+  %(fulltext_key)s as keys,
+
+  ts_rank_cd(module_idx, plainto_tsquery(%(text_terms)s),4) * 2 ^ length(to_tsvector(%(text_terms)s)) as weight
+
+FROM
+
+  latest_modules cm,
+
+  modulefti mf
+
+WHERE
+
+  cm.module_ident = mf.module_ident
+
+-- text_terms
+  {5}
+
+-- pubYear
+  {0}
+
+-- authorID
+  {1}
+
+-- type
+  {2}
+
+-- keyword
+  {3}
+
+-- subject
+  {4}
+
+-- language
+  {6}
+
+-- title
+  {7}
+
+-- author
+  {8}
+
+  ),
+
+derived_weighted_query_results AS (
+  SELECT
+    wqr.module_ident,
+    CASE WHEN lm.parent IS NULL THEN weight + 1
+         ELSE weight
+    END AS weight,
+    keys
+  FROM weighted_query_results AS wqr
+       LEFT JOIN latest_modules AS lm ON (wqr.module_ident = lm.module_ident)
+  )
+SELECT
+  lm.name as title, title_order(lm.name) as "sortTitle",
+  lm.uuid as id,
+  CASE
+    WHEN lm.portal_type = 'Collection'
+      THEN lm.major_version || '.' || lm.minor_version
+    ELSE lm.major_version || ''
+  END AS version,
+  language,
+  lm.portal_type as "mediaType",
+  iso8601(lm.revised) as "pubDate",
+  ARRAY(SELECT k.word FROM keywords as k, modulekeywords as mk
+        WHERE mk.module_ident = lm.module_ident
+              AND mk.keywordid = k.keywordid) as keywords,
+  ARRAY(SELECT tags.tag FROM tags, moduletags as mt
+        WHERE mt.module_ident = lm.module_ident
+              AND mt.tagid = tags.tagid) as subjects,
+  ARRAY(SELECT row_to_json(user_rows) FROM
+        (SELECT username as id,
+                first_name as firstname, last_name as surname,
+                full_name as fullname, title, suffix
+         FROM users
+         WHERE users.username::text = ANY (lm.authors)
+         ) as user_rows) as authors,
+  -- The following are used internally for further sorting and debugging.
+  weight, rank,
+  keys as _keys, '' as matched, '' as fields,
+  ts_headline(ab.html,plainto_tsquery(%(text_terms)s), 'ShortWord=5, MinWords=50, MaxWords=60') as abstract,
+  -- until we actually do something with it
+  -- ts_headline(mfti.fulltext, plainto_tsquery(%(text_terms)s),
+  --            'StartSel=<b>, StopSel=</b>, ShortWord=5, MinWords=50, MaxWords=60') as headline
+  NULL as headline
+-- Only retrieve the most recent published modules.
+FROM
+  latest_modules AS lm
+  NATURAL LEFT JOIN abstracts AS ab
+  NATURAL LEFT JOIN modulefti AS mfti
+
+  LEFT OUTER JOIN recent_hit_ranks ON (lm.uuid = document),
+  derived_weighted_query_results AS wqr
+WHERE
+  wqr.module_ident = lm.module_ident
+  AND lm.portal_type not in  ('CompositeModule','SubCollection')
+
+-- sort
+ORDER BY {sorts}
+
+) as combined_rows
+;

--- a/cnxdb/migrations/20180724165111_add-latest-modules-indices.py
+++ b/cnxdb/migrations/20180724165111_add-latest-modules-indices.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
+def up(cursor):
+    cursor.execute("""
+           CREATE FUNCTION year(ts timestamptz)
+               RETURNS DOUBLE PRECISION IMMUTABLE AS $$
+               SELECT EXTRACT(year from ts)
+               $$ LANGUAGE SQL;""")
+    cursor.execute("""
+        	CREATE INDEX latest_modules_gin_authors_idx ON latest_modules using gin(authors);
+       		CREATE INDEX latest_modules_publication_year_idx ON latest_modules (year(revised));
+        """)
+
+
+
+def down(cursor):
+    cursor.execute("""
+    		DROP INDEX latest_modules_gin_authors_idx;
+    		DROP INDEX latest_modules_publication_year_idx;
+    		DROP FUNCTION year(timestamptz);
+    	""")

--- a/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
+++ b/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
@@ -13,23 +13,23 @@ def up(cursor):
         _idx_text_vectors tsvector;
         _idx_title_vectors tsvector;
         _idx_keyword_vectors tsvector;
-
+    
       BEGIN
         has_existing_record := (SELECT module_ident FROM modulefti WHERE module_ident = NEW.module_ident);
         _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text
-                      FROM files AS f WHERE f.fileid = NEW.fileid);
+                        FROM files AS f WHERE f.fileid = NEW.fileid);
         _keyword := (SELECT k.word FROM keywords k INNER JOIN modulekeywords m
-                     ON k.keywordid = m.keywordid
-                     AND m.module_ident = NEW.module_ident);
+                       ON k.keywordid = m.keywordid
+                        AND m.module_ident = NEW.module_ident);
         _title := (SELECT modules.name FROM modules WHERE module_ident = NEW.module_ident);
         _idx_title_vectors := setweight(to_tsvector(COALESCE(_title, '')), 'A');
         _idx_keyword_vectors := setweight(to_tsvector(COALESCE(_keyword, '')), 'B');
         _idx_text_vectors := setweight(to_tsvector(COALESCE(_baretext, '')), 'C');
-
+    
         IF has_existing_record IS NULL THEN
           INSERT INTO modulefti (module_ident, fulltext, module_idx)
             VALUES ( NEW.module_ident, _baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors);
-
+    
         ELSE
           UPDATE modulefti
             SET (fulltext, module_idx) = (_baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors)

--- a/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
+++ b/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION index_fulltext_trigger()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        has_existing_record integer;
+        _baretext text;
+        _keyword text;
+        _title text;
+        _idx_text_vectors tsvector;
+        _idx_title_vectors tsvector;
+        _idx_keyword_vectors tsvector;
+
+      BEGIN
+        has_existing_record := (SELECT module_ident FROM modulefti WHERE module_ident = NEW.module_ident);
+        _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text
+                      FROM files AS f WHERE f.fileid = NEW.fileid);
+        _keyword := (SELECT k.word FROM keywords k INNER JOIN modulekeywords m
+                     ON k.keywordid = m.keywordid
+                     AND m.module_ident = NEW.module_ident);
+        _title := (SELECT modules.name FROM modules WHERE module_ident = NEW.module_ident);
+        _idx_title_vectors := setweight(to_tsvector(COALESCE(_title, '')), 'A');
+        _idx_keyword_vectors := setweight(to_tsvector(COALESCE(_keyword, '')), 'B');
+        _idx_text_vectors := setweight(to_tsvector(COALESCE(_baretext, '')), 'C');
+
+        IF has_existing_record IS NULL THEN
+          INSERT INTO modulefti (module_ident, fulltext, module_idx)
+            VALUES ( NEW.module_ident, _baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors);
+
+        ELSE
+          UPDATE modulefti
+            SET (fulltext, module_idx) = (_baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors)
+              WHERE module_ident = NEW.module_ident;
+        END IF;
+        RETURN NEW;
+      END;
+      $$
+      LANGUAGE plpgsql;
+      """)
+
+
+def down(cursor):
+    cursor.execute("""
+    CREATE OR REPLACE FUNCTION index_fulltext_trigger()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        has_existing_record integer;
+        _baretext text;
+        _idx_vectors tsvector;
+      BEGIN
+        has_existing_record := (SELECT module_ident FROM modulefti WHERE module_ident = NEW.module_ident);
+        _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text FROM files AS f WHERE f.fileid = NEW.fileid);
+        _idx_vectors := to_tsvector(_baretext);
+
+        IF has_existing_record IS NULL THEN
+          INSERT INTO modulefti (module_ident, fulltext, module_idx)
+            VALUES ( NEW.module_ident, _baretext, _idx_vectors );
+        ELSE
+          UPDATE modulefti SET (fulltext, module_idx) = ( _baretext, _idx_vectors )
+            WHERE module_ident = NEW.module_ident;
+        END IF;
+        RETURN NEW;
+      END;
+      $$
+      LANGUAGE plpgsql;
+      """)

--- a/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
+++ b/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
@@ -4,8 +4,8 @@ from dbmigrator import deferred
 
 def update_module_idx(cursor):
     cursor.execute("""
-    UPDATE module_files SET module_ident = module_ident WHERE filename="index.cnxml.html";
-    UPDATE latest_modules SET module_ident = module_ident WHERE portal_type="Collection";
+    UPDATE module_files SET module_ident = module_ident WHERE filename='index.cnxml.html';
+    UPDATE latest_modules SET module_ident = module_ident WHERE portal_type='Collection';
     """)
 
 

--- a/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
+++ b/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
@@ -4,41 +4,50 @@
 def up(cursor):
     cursor.execute("""
     CREATE OR REPLACE FUNCTION index_fulltext_trigger()
-      RETURNS TRIGGER AS $$
-      DECLARE
-        has_existing_record integer;
-        _baretext text;
-        _keyword text;
-        _title text;
-        _idx_text_vectors tsvector;
-        _idx_title_vectors tsvector;
-        _idx_keyword_vectors tsvector;
-    
-      BEGIN
-        has_existing_record := (SELECT module_ident FROM modulefti WHERE module_ident = NEW.module_ident);
-        _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text
-                        FROM files AS f WHERE f.fileid = NEW.fileid);
-        _keyword := (SELECT k.word FROM keywords k INNER JOIN modulekeywords m
-                       ON k.keywordid = m.keywordid
-                        AND m.module_ident = NEW.module_ident);
-        _title := (SELECT modules.name FROM modules WHERE module_ident = NEW.module_ident);
-        _idx_title_vectors := setweight(to_tsvector(COALESCE(_title, '')), 'A');
-        _idx_keyword_vectors := setweight(to_tsvector(COALESCE(_keyword, '')), 'B');
-        _idx_text_vectors := setweight(to_tsvector(COALESCE(_baretext, '')), 'C');
-    
-        IF has_existing_record IS NULL THEN
-          INSERT INTO modulefti (module_ident, fulltext, module_idx)
-            VALUES ( NEW.module_ident, _baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors);
-    
-        ELSE
-          UPDATE modulefti
-            SET (fulltext, module_idx) = (_baretext, _idx_title_vectors || _idx_keyword_vectors || _idx_text_vectors)
-              WHERE module_ident = NEW.module_ident;
-        END IF;
-        RETURN NEW;
-      END;
-      $$
-      LANGUAGE plpgsql;
+  RETURNS TRIGGER AS $$
+  DECLARE
+    has_existing_record integer;
+    _baretext text;
+    _keyword text;
+    _title text;
+    _abstract text;
+    _idx_text_vectors tsvector;
+    _idx_title_vectors tsvector;
+    _idx_keyword_vectors tsvector;
+    _idx_abstract_vectors tsvector;
+
+  BEGIN
+    has_existing_record := (SELECT module_ident FROM modulefti WHERE module_ident = NEW.module_ident);
+    _baretext := (SELECT xml_to_baretext(convert_from(f.file, 'UTF8')::xml)::text
+                    FROM files AS f WHERE f.fileid = NEW.fileid);
+    _keyword := (SELECT LIST(k.word) FROM keywords k INNER JOIN modulekeywords m
+                   ON k.keywordid = m.keywordid
+                    WHERE m.module_ident = NEW.module_ident);
+    _title := (SELECT modules.name FROM modules WHERE module_ident = NEW.module_ident);
+    _abstract := (SELECT ab.abstract FROM abstracts ab INNER JOIN modules m
+                   ON ab.abstractid = m.abstractid
+                    WHERE m.module_ident = NEW.module_ident);
+    _idx_title_vectors := setweight(to_tsvector(COALESCE(_title, '')), 'A');
+    _idx_keyword_vectors := setweight(to_tsvector(COALESCE(_keyword, '')), 'B');
+    _idx_abstract_vectors := setweight(to_tsvector(COALESCE(_abstract, '')), 'B');
+    _idx_text_vectors := setweight(to_tsvector(COALESCE(_baretext, '')), 'C');
+
+
+    IF has_existing_record IS NULL THEN
+      INSERT INTO modulefti (module_ident, fulltext, module_idx)
+        VALUES ( NEW.module_ident, _baretext, _idx_title_vectors || _idx_keyword_vectors
+                 || _idx_abstract_vectors || _idx_text_vectors);
+
+    ELSE
+      UPDATE modulefti
+        SET (fulltext, module_idx) = (_baretext, _idx_title_vectors || _idx_keyword_vectors
+             || _idx_abstract_vectors || _idx_text_vectors)
+          WHERE module_ident = NEW.module_ident;
+    END IF;
+    RETURN NEW;
+  END;
+  $$
+  LANGUAGE plpgsql;
       """)
 
 

--- a/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
+++ b/cnxdb/migrations/20180724183730_modify-index-fulltext-trigger.py
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
+from dbmigrator import deferred
 
 
+def update_module_idx(cursor):
+    cursor.execute("""
+    UPDATE module_files SET module_ident = module_ident WHERE filename="index.cnxml.html";
+    UPDATE latest_modules SET module_ident = module_ident WHERE portal_type="Collection";
+    """)
+
+
+@deferred
 def up(cursor):
     cursor.execute("""
     CREATE OR REPLACE FUNCTION index_fulltext_trigger()
@@ -49,6 +58,7 @@ def up(cursor):
   $$
   LANGUAGE plpgsql;
       """)
+    update_module_idx(cursor)
 
 
 def down(cursor):
@@ -76,3 +86,4 @@ def down(cursor):
       $$
       LANGUAGE plpgsql;
       """)
+    update_module_idx(cursor)

--- a/cnxdb/migrations/20180803144633_drop-extra-gist-index.py
+++ b/cnxdb/migrations/20180803144633_drop-extra-gist-index.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from dbmigrator import deferred
+
+
+def helper(cursor, create_idx, drop_idx, table_name, method, create):
+    excpt = None
+    # Try creating or drop an index concurrently for at most three times
+    tries = 3
+    while tries > 0:
+        tries -= 1
+        try:
+            if create:
+                # Try creating a new index concurrently
+                cursor.execute("CREATE INDEX CONCURRENTLY {} ON {} USING {}"
+                               .format(create_idx, table_name, method))
+            else:
+                # Try dropping the old index concurrently
+                cursor.execute("DROP INDEX CONCURRENTLY IF EXISTS {}".format(drop_idx))
+
+        except Exception as e:
+            excpt = e
+            if create:
+                # Drop the incomplete new index if it fails to be created
+                cursor.execute("DROP INDEX IF EXISTS {}".format(create_idx))
+            continue
+        break
+    else:
+        raise excpt
+
+
+@deferred
+def up(cursor):
+    cursor.connection.rollback()
+    cursor.connection.autocommit = True
+    # Drop the GIST index
+    helper(cursor, None, 'modulefti_module_idx_idx', None, None, False)
+
+
+def down(cursor):
+    cursor.connection.rollback()
+    cursor.connection.autocommit = True
+    # Create the GIST index
+    helper(cursor, 'modulefti_module_idx_idx', None, "modulefti", "gist(module_idx)", True)

--- a/cnxdb/migrations/20180803144633_drop-extra-gist-index.py
+++ b/cnxdb/migrations/20180803144633_drop-extra-gist-index.py
@@ -38,7 +38,3 @@ def up(cursor):
 
 def down(cursor):
     return
-    # cursor.connection.rollback()
-    # cursor.connection.autocommit = True
-    # # Create the GIST index
-    # helper(cursor, 'modulefti_module_idx_idx', None, "modulefti", "gist(module_idx)", True)

--- a/cnxdb/migrations/20180803144633_drop-extra-gist-index.py
+++ b/cnxdb/migrations/20180803144633_drop-extra-gist-index.py
@@ -37,7 +37,8 @@ def up(cursor):
 
 
 def down(cursor):
-    cursor.connection.rollback()
-    cursor.connection.autocommit = True
-    # Create the GIST index
-    helper(cursor, 'modulefti_module_idx_idx', None, "modulefti", "gist(module_idx)", True)
+    return
+    # cursor.connection.rollback()
+    # cursor.connection.autocommit = True
+    # # Create the GIST index
+    # helper(cursor, 'modulefti_module_idx_idx', None, "modulefti", "gist(module_idx)", True)


### PR DESCRIPTION
Rewrote the index_fulltext_trigger so that it can set different weights to tsvectors based on whether they are generated on titles, keywords, or texts.