### PR TITLE
Fixed the get-collated-content query so it uses the existing ident_hash index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,21 @@ sudo: required
 dist: precise
 addons:
   postgresql: "9.4"
+  apt:
+    packages:
+      - libxml2-dev
+      - libxslt-dev
+      - postgresql-plpython-9.4
+      - postgresql-plpython3-9.4
+      - postgresql-server-dev-9.4
 before_install:
   - pip install -r requirements/test.txt
+  - export PYTHON_VERSION=${TRAVIS_PYTHON_VERSION%.*}
   - make lint
 
-  - sudo apt-get update
   # remove zope.interface installed from aptitude
   - sudo apt-get purge python-zope.interface
 
-  # * Install the 'plpython' extension language
-  - sudo apt-get install postgresql-plpython-9.4 postgresql-plpython3-9.4
-  # * Install the 'plxslt' extension language
-  - sudo apt-get install libxml2-dev libxslt-dev postgresql-server-dev-9.4
   - git clone https://github.com/petere/plxslt.git
   - cd plxslt && sudo make && sudo make install && cd ..
   # * Install rhaptos.cnxmlutils
@@ -28,19 +31,19 @@ before_install:
   - pip install codecov
 
   # Use plpython3u for python 3 tests
-  - if [[ -n "$(python --version | grep 'Python 3')" ]]; then sed -i 's/plpythonu/plpython3u/' $(git grep -l plpythonu cnxdb/ tests/); fi
+  - if [[ $PYTHON_VERSION -eq 3 ]]; then sed -i 's/plpythonu/plpython3u/' $(git grep -l plpythonu cnxdb/ tests/); fi
 install:
   # Uninstall, because cnx-archive installs it due to the circular dependence.
   - pip uninstall -y cnx-db
   - pip install .
 before_script:
   # Set up postgres roles
-  - sudo -u postgres psql -d postgres -c "CREATE USER tester WITH SUPERUSER PASSWORD 'tester';"
+  - psql -U postgres -c "CREATE USER tester WITH SUPERUSER PASSWORD 'tester';"
   # Set up the database
-  - sudo -u postgres createdb -O tester testing
+  - createdb -U postgres -O tester testing
   - git clone https://github.com/okbob/session_exec.git
   - cd session_exec
-  - git reset --hard dde5cb7661d659fcc4fc3133f9a1e463e82c088c
+  - git checkout dc2885e08fbd1ebef9170047fde53167b1f28c70
   - make USE_PGXS=1 -e && sudo make USE_PGXS=1 -e install
   - cd ..
   - export PYPREFIX=$(python -c 'import sys; print(sys.prefix)')

--- a/cnxdb/archive-sql/get-collated-content.sql
+++ b/cnxdb/archive-sql/get-collated-content.sql
@@ -13,5 +13,5 @@ FROM collated_file_associations AS cfa
                modules AS item
 WHERE cfa.context = context.module_ident AND
       cfa.item = item.module_ident AND
-      item.uuid || '@' || module_version(item.major_version, item.minor_version) = %s AND
-      context.uuid || '@' || module_version(context.major_version, context.minor_version) = %s
+      ident_hash(item.uuid, item.major_version, item.minor_version) = %s AND
+      ident_hash(context.uuid, context.major_version, context.minor_version) = %s


### PR DESCRIPTION
Speeds up this query (which seems to run twice for all book content) from ~2 seconds to a few milliseconds by allowing it to use the existing ident_hash() index. Should help improve book load times on CNX and possibly overall CNX archive performance.