### PR TITLE
Order available languages query for consistent results

### DIFF
--- a/cnxdb/archive-sql/get-available-languages-and-count.sql
+++ b/cnxdb/archive-sql/get-available-languages-and-count.sql
@@ -8,4 +8,5 @@
 -- arguments: N/A
 SELECT language, count(language)
 FROM latest_modules
-group by language;
+GROUP BY language
+ORDER BY language;


### PR DESCRIPTION
Archive tests were failing on OS X due to the lack of ordering for the languages.