### PR TITLE
Make schema pg_dump-able

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ script:
   - py.test --cov="$PYPREFIX/lib/$PYVERDIR/site-packages/cnxdb"
   # If this is python3, we need to undo the plpython3u changes
   - git reset --hard HEAD
+  # Test dump/restore
+  - script/ci_test_dump_restore.sh
   # Test migrations
   - script/ci_test_migrations.sh
 after_success:

--- a/cnxdb/archive-sql/schema/functions.sql
+++ b/cnxdb/archive-sql/schema/functions.sql
@@ -196,7 +196,7 @@ CREATE OR REPLACE FUNCTION short_ident_hash(uuid uuid, major integer, minor inte
  RETURNS text
  LANGUAGE sql
  IMMUTABLE
-AS $function$ select short_id(uuid) || '@' || concat_ws('.', major, minor) $function$;
+AS $function$ select public.short_id(uuid) || '@' || concat_ws('.', major, minor) $function$;
 
 CREATE FUNCTION year(ts timestamptz)
   RETURNS DOUBLE PRECISION IMMUTABLE

--- a/cnxdb/migrations/20180816211433_dumpable-functions.py
+++ b/cnxdb/migrations/20180816211433_dumpable-functions.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+
+# Uncomment should_run if this is a repeat migration
+# def should_run(cursor):
+#     # TODO return True if migration should run
+
+
+def up(cursor):
+    cursor.execute('''
+CREATE OR REPLACE FUNCTION
+ short_ident_hash(uuid uuid, major integer, minor integer)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $$ select public.short_id(uuid) || '@' || concat_ws('.', major, minor) $$
+''')
+
+
+def down(cursor):
+    cursor.execute('''
+CREATE OR REPLACE FUNCTION
+short_ident_hash(uuid uuid, major integer, minor integer)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS $$ select short_id(uuid) || '@' || concat_ws('.', major, minor) $$
+''')

--- a/script/ci_test_dump_restore.sh
+++ b/script/ci_test_dump_restore.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+export DB_URL='postgresql://tester:tester@localhost:5432/testing'
+
+# set up the database
+dropdb -U postgres testing
+createdb -U postgres -O tester testing
+cnx-db init
+
+# store the schema
+pg_dump -s 'dbname=testing user=tester' >schema.sql
+
+# Recreate the DB, and restore it
+dropdb -U postgres testing
+createdb -U postgres -O tester testing
+psql -U postgres testing -f schema.sql
+pg_dump -s 'dbname=testing user=tester' >restored_schema.sql
+
+# check schema
+dumprestore=$(diff -wu schema.sql restored_schema.sql || true)
+
+if [ -n "$dumprestore" ]
+then
+    echo "Dump/restore test failed:"
+    diff -wu schema.sql restored_schema.sql || true
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
use explicit namespace in functions calls from functions used for indexes

This was causing failure to dump the db. Don't know why production can currently dump: perhaps psql 9.4.X can dump, but >9.5 triggers the problem? 

I want to add tests that dump and restore the DB after init. No need for test data.

Upstream links:
https://stackoverflow.com/questions/49380321/pg-restore-cant-import-data-if-table-has-a-constraint-with-a-function-calling
https://bucardo.org/postgres_all_versions.html#version_9.3.22
https://www.postgresql.org/message-id/flat/152153826367.11956.8092048336300020216%40wrigleys.postgresql.org