### PR TITLE
fix production functions with wrong owner

### DIFF
--- a/cnxdb/migrations/20180816162942_fix-function-ownership.py
+++ b/cnxdb/migrations/20180816162942_fix-function-ownership.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from dbmigrator import super_user
+
+
+def up(cursor):
+    cursor.execute('SELECT current_user')
+    username = cursor.fetchall()[0][0]
+    with super_user() as super_cursor:
+        super_cursor.execute('''
+ALTER FUNCTION ident_hash (uuid, integer, integer) OWNER TO {user};
+ALTER FUNCTION is_baked (uuid, text) OWNER TO {user};
+ALTER FUNCTION short_ident_hash (uuid, integer, integer) OWNER TO {user};
+ALTER FUNCTION shred_collxml (integer, integer, boolean) OWNER TO {user};
+ALTER FUNCTION shred_collxml (text, integer) OWNER TO {user};
+ALTER FUNCTION strip_html (text) OWNER TO {user};
+ALTER FUNCTION subcol_uuids (uuid, text) OWNER TO {user};
+ALTER FUNCTION uuid5 (uuid, text) OWNER TO {user};
+'''.format(user=username))
+
+
+def down(cursor):
+    # TODO rollback code
+    pass


### PR DESCRIPTION
Production somehow has different ownership for these eight functions than happens from a fresh 
DB deployment. This code fixes them.