### PR TITLE
Build the Docker image and Python distribution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 ./.state
 ./dist
 ./build
+./.jenkins

--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -1,0 +1,34 @@
+pipeline {
+  agent { label 'docker' }
+  stages {
+    stage('Build') {
+      steps {
+        sh "docker build --build-arg environment=prod -t openstax/cnx-db:dev ."
+      }
+    }
+    stage('Publish Dev Container') {
+      steps {
+        // 'docker-registry' is defined in Jenkins under credentials
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker push openstax/cnx-db:dev"
+        }
+      }
+    }
+    stage('Publish Release') {
+      when {
+        expression {
+          release = sh(returnStdout: true, script: 'git tag -l --points-at HEAD | head -n 1').trim()
+          return release
+        }
+      }
+      steps {
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker tag openstax/cnx-db:dev openstax/cnx-db:${release}"
+          sh "docker tag openstax/cnx-db:dev openstax/cnx-db:latest"
+          sh "docker push openstax/cnx-db:${release}"
+          sh "docker push openstax/cnx-db:latest"
+        }
+      }
+    }
+  }
+}

--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -21,7 +21,7 @@ pipeline {
       }
       when {
         expression {
-          release = sh(returnStdout: true, script: 'git tag -l --points-at HEAD | head -n 1').trim()
+          release = sh(returnStdout: true, script: 'git tag -l --points-at HEAD | head -n 1 | sed -e "s/^v//"').trim()
           return release
         }
       }

--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -15,6 +15,10 @@ pipeline {
       }
     }
     stage('Publish Release') {
+      environment {
+        TWINE_USERNAME = 'openstax'
+        TWINE_PASSWORD = credentials('pypi-openstax-password')
+      }
       when {
         expression {
           release = sh(returnStdout: true, script: 'git tag -l --points-at HEAD | head -n 1').trim()
@@ -28,6 +32,9 @@ pipeline {
           sh "docker push openstax/cnx-db:${release}"
           sh "docker push openstax/cnx-db:latest"
         }
+        // FIXME Note, this uses the Test PyPI. Since we are unable to test these changes prior to use, the first occurance will be test test.
+        // Note, '.git' is a volume, because versioneer needs it to resolve the python distribution's version. 
+        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${PWD}/.git:/src/.git:ro openstax/cnx-db:latest /bin/bash -c \"pip install -q twine && python setup.py bdist_wheel --universal && twine upload --repository-url https://test.pypi.org/legacy/ dist/*\""
       }
     }
   }


### PR DESCRIPTION
This automates the building of the docker container and python distribution on release.

On a typical merge build this will build an `openstax/cnx-db:dev` image. The `openstax/cnx-db:dev` image should therefore always represent the tip of `master`. That image is also released as `openstax/cnx-db:${version}` when a tag is created.

When a tag is created this will release the `cnx-db-${version}.whl` (Python Wheel) to pypi.org.

Note, this pull request is setup to work against the test instance of PyPI. This will test that part of this configuration prior to us using it. After we've verified it works, we can remove the `FIXME` and `--repository-url https://test.pypi.org/legacy/` option to twine.

Addresses https://github.com/openstax/quality-assurance-meta/issues/82