### PR TITLE
Migration fixes

### DIFF
--- a/cnxdb/migrations/20180926215317_set-canonical.py
+++ b/cnxdb/migrations/20180926215317_set-canonical.py
@@ -11,7 +11,9 @@ def _batcher(seq, size):
 
 
 def should_run(cursor, limit='limit 1'):
-    cursor.execute("""SELECT module_ident FROM modules WHERE canonical is null {}""".format(limit))
+    cursor.execute("SELECT module_ident FROM modules WHERE canonical is null"
+                   " AND portal_type in ('Module', 'CompositeModule')"
+                   " {}".format(limit))
     return cursor.fetchall()
 
 

--- a/cnxdb/migrations/20181023135904_build-collxml.py
+++ b/cnxdb/migrations/20181023135904_build-collxml.py
@@ -34,7 +34,7 @@ def _build_collxml(collid, cursor):
     WITH collxml as (
         INSERT INTO files (file, media_type)
             SELECT pretty_print(legacy_collxml(%s, True))::text::bytea,
-                  'text/xml')
+                  'text/xml'
         RETURNING fileid)
     INSERT INTO module_files (module_ident, fileid, filename)
             SELECT %s, fileid, 'collection.xml' from collxml""",


### PR DESCRIPTION
The collxml builder migration has an outright bug. The canonical setter migration is overly aggressive. This PR fixes both.