### PR TITLE
Adjust the container POSTGRES_USER value

### DIFF
--- a/.dockerfiles/initdb.d/00_initdb.sh
+++ b/.dockerfiles/initdb.d/00_initdb.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 set -e
 
-psql -v ON_ERROR_STOP=1 --username postgres <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username ${POSTGRES_USER} <<-EOSQL
+    CREATE USER rhaptos_admin SUPERUSER;
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username rhaptos_admin -d postgres <<-EOSQL
     CREATE USER ${DB_USER};
     CREATE USER backups;
     ALTER DATABASE "${POSTGRES_DB}" OWNER TO ${DB_USER};
-    GRANT ALL PRIVILEGES ON DATABASE "${POSTGRES_DB}" TO ${POSTGRES_USER};
     GRANT ALL PRIVILEGES ON DATABASE "${POSTGRES_DB}" TO ${DB_USER};
-    \c "${POSTGRES_DB}" ${POSTGRES_USER}
-    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA PUBLIC TO ${POSTGRES_USER};
+    \c "${POSTGRES_DB}" rhaptos_admin
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA PUBLIC TO ${DB_USER};
 EOSQL
+
 
 if [ -z "`ls /docker-entrypoint-initdb.d/*.sql.gz`" -a -z  "`ls /docker-entrypoint-initdb.d/*.sql`" ]; then
     cnx-db init
 fi
 
 # ??? Is this really what we want to be doing?
-psql -v ON_ERROR_STOP=1 --username postgres "$POSTGRES_DB" <<-EOSQL
-    REASSIGN OWNED BY ${POSTGRES_USER} TO ${DB_USER};
+psql -v ON_ERROR_STOP=1 --username ${POSTGRES_USER} "$POSTGRES_DB" <<-EOSQL
+    REASSIGN OWNED BY rhaptos_admin TO ${DB_USER};
 EOSQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM openstax/postgres:9.4
 
-MAINTAINER Michael Mulich <michael.mulich@gmail.com>
-
 RUN apt-get update
 
 # Install build dependencies
@@ -50,13 +48,11 @@ EXPOSE 5432
 # This is a specially created user for non-superuser operations.
 ENV DB_USER=rhaptos
 
-# We use the 'rhaptos_admin' user for superuser operations.
-ENV POSTGRES_USER=rhaptos_admin
 ENV POSTGRES_DB=repository
 
 # These are used by this codebase's tools (e.g. `cnxdb init`).
-ENV DB_URL=postgresql://rhaptos@localhost/repository
-ENV DB_SUPER_URL=postgresql://postgres@localhost/repository
+ENV DB_URL=postgresql://rhaptos@/repository
+ENV DB_SUPER_URL=postgresql://rhaptos_admin@/repository
 
 # This is a hook into the postgres:* container to do database init
 COPY .dockerfiles/initdb.d/* /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - DB_URL=postgresql://rhaptos@localhost/repository
-      - DB_SUPER_URL=postgresql://postgres@localhost/repository
+      - DB_URL=postgresql://rhaptos@/repository
+      - DB_SUPER_URL=postgresql://postgres@/repository
 volumes:
   pg-data:


### PR DESCRIPTION
Upstream changes have made it so the `postgres` role is no longer created
along with the `$POSTGRES_USER`, which defaults to `postgres`.
Because of this, we'll stick with the default and create our superuser
in the init script.

These changes should keep things the same, just reorder them slightly.

This will hopefully resolve the issue @BryanEliDimas is seeing on Travis for Press (and Archive). That problem I believe has to do with upstream security updates that have changed how the container functions. We've run into this kind of thing before. The upstream container `openstax/postgres:9.4` has been updated. But the update also has upstream changes to `$POSTGRES_USER` behavior, which is why these changes have been created.