### PR TITLE
Allow tests to run in docker-compose environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 ./dist
 ./build
 ./.jenkins
+./.venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,9 @@
 language: python
 services:
   - docker
-python:
-  - "2.7"
-  - "3.5"
 sudo: required
 dist: trusty
-addons:
-  postgresql: "9.4"
-  apt:
-    packages:
-      - libxml2-dev
-      - libxslt-dev
-      - postgresql-plpython-9.4
-      - postgresql-plpython3-9.4
-      - postgresql-server-dev-9.4
-before_install:
-  # Uninstall default pytest because it is old
-  - pip uninstall -y pytest
-  - pip install --upgrade pip
-  - pip install -r requirements/test.txt
-  - export PYTHON_VERSION=${TRAVIS_PYTHON_VERSION%.*}
-  - make lint
-
-  # remove zope.interface installed from aptitude
-  - sudo apt-get purge python-zope.interface
-
-  - git clone https://github.com/petere/plxslt.git
-  - cd plxslt && sudo make && sudo make install && cd ..
-  # * Install rhaptos.cnxmlutils
-  # - git clone https://github.com/Connexions/rhaptos.cnxmlutils.git
-  # - cd rhaptos.cnxmlutils && python setup.py install && cd ..
-
-  # Install the coverage utility and codecov reporting utility
-  - pip install codecov
-
-  # Use plpython3u for python 3 tests
-  - if [[ $PYTHON_VERSION -eq 3 ]]; then sed -i 's/plpythonu/plpython3u/' $(git grep -l plpythonu cnxdb/ tests/); fi
-install:
-  # Uninstall, because cnx-archive installs it due to the circular dependence.
-  - pip uninstall -y cnx-db
-  - pip install .
-before_script:
-  # Set up postgres roles
-  - psql -U postgres -c "CREATE USER tester WITH SUPERUSER PASSWORD 'tester';"
-  # Set up the database
-  - createdb -U postgres -O tester testing
-  - git clone https://github.com/okbob/session_exec.git
-  - cd session_exec
-  - git checkout dc2885e08fbd1ebef9170047fde53167b1f28c70
-  - make USE_PGXS=1 -e && sudo make USE_PGXS=1 -e install
-  - cd ..
-  - export PYPREFIX=$(python -c 'import sys; print(sys.prefix)')
-  - export PYVERDIR=$(python -c 'import sys; print("python%d.%d" % sys.version_info[:2])')
 script:
-  # This is the same as `python setup.py test` with a coverage wrapper.
-  - py.test --cov="$PYPREFIX/lib/$PYVERDIR/site-packages/cnxdb"
-  # If this is python3, we need to undo the plpython3u changes
-  - git reset --hard HEAD
-  # Test dump/restore
-  - script/ci_test_dump_restore.sh
-  # Test migrations
-  - script/ci_test_migrations.sh
-  # Check dist
-  - script/ci_check_dist.sh
-  # Try out the docker scripts
   - ./script/tests.local.sh
 after_success:
   # Report test coverage to codecov.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
+services:
+  - docker
 python:
   - "2.7"
   - "3.5"
 sudo: required
-dist: precise
+dist: trusty
 addons:
   postgresql: "9.4"
   apt:
@@ -62,6 +64,8 @@ script:
   - script/ci_test_migrations.sh
   # Check dist
   - script/ci_check_dist.sh
+  # Try out the docker scripts
+  - ./script/tests.local.sh
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 # Install build dependencies
 RUN set -x \
     && apt-get update \
-    && apt-get install build-essential pkg-config git python-pip --no-install-recommends -y \
+    && apt-get install build-essential pkg-config git python-pip python3-dev python3-venv --no-install-recommends -y \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -22,11 +22,18 @@ RUN set -x \
     && cd plxslt \
     && make \
     && make install
+    
+RUN set -x \
+    && git clone https://github.com/okbob/session_exec.git \
+    && cd session_exec \
+    && git checkout dc2885e08fbd1ebef9170047fde53167b1f28c70 \
+    && make USE_PGXS=1 -e && make USE_PGXS=1 -e install
 
 # Upgrade pip and packaging tools
 RUN set -x \
     && pip install -U pip setuptools wheel \
-    && apt remove python-pip -y
+    && apt remove python-pip -y \
+    && apt-get install python3-venv
 
 COPY requirements /tmp/requirements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,21 @@ RUN set -x \
 # Install the 'plxslt' extension language
 RUN set -x \
     && apt-get update \
-    && apt-get install libxml2-dev libxslt-dev zlib1g-dev postgresql-server-dev-$PG_MAJOR --no-install-recommends -y \
+    && apt-get install curl libxml2-dev libxslt-dev zlib1g-dev postgresql-server-dev-$PG_MAJOR --no-install-recommends -y \
     && git clone https://github.com/petere/plxslt.git \
     && cd plxslt \
     && make \
     && make install
-    
+
+# Install session_exec. Create db sessions using python in a venv
 RUN set -x \
     && git clone https://github.com/okbob/session_exec.git \
     && cd session_exec \
     && git checkout dc2885e08fbd1ebef9170047fde53167b1f28c70 \
     && make USE_PGXS=1 -e && make USE_PGXS=1 -e install
+
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/54d1f0bfeb6557adf8a3204455389d0901652242/wait-for-it.sh \
+  -o /usr/local/bin/wait-for-it && chmod a+x /usr/local/bin/wait-for-it
 
 # Upgrade pip and packaging tools
 RUN set -x \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ recursive-include docs *.*
 recursive-exclude docs/_build *.*
 include versioneer.py
 include cnxdb/_version.py
+recursive-include requirements/ *.txt

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -12,7 +12,7 @@ help:
 	@echo "        Run doc8 using tox for document style linting."
 
 test:
-	tox -e py2,py3
+	tox -e py27,py3
 
 flake8:
 	tox -e flake8

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,30 @@
+# A Makefile that assumes the commands will be executed in relation to docker.
+
+help:
+	@echo "make"
+	@echo "    clean"
+	@echo "        Remove Python/build artifacts."
+	@echo "    test"
+	@echo "        Run the test suite using tox for python 2 and python 3."
+	@echo "    flake8"
+	@echo "        Run flake8 using tox for code style linting."
+	@echo "    doc8"
+	@echo "        Run doc8 using tox for document style linting."
+
+test:
+	tox -e py2,py3
+
+flake8:
+	tox -e flake8
+
+doc8:
+	tox -e doc8
+
+clean:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f  {} +
+	rm -rf build/
+	rm -rf .pytype/
+	rm -rf dist/
+	rm -rf docs/_build

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -10,6 +10,8 @@ help:
 	@echo "        Run flake8 using tox for code style linting."
 	@echo "    doc8"
 	@echo "        Run doc8 using tox for document style linting."
+	@echo "    db-wait"
+	@echo "        Run db_wait.py script to check if the database is up"
 
 test:
 	tox -e py27,py3
@@ -19,6 +21,9 @@ flake8:
 
 doc8:
 	tox -e doc8
+
+db-wait:
+	./script/db_wait.py
 
 clean:
 	find . -name '*.pyc' -exec rm -f {} +

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,7 @@ services:
   db:
     build: .
     volumes:
-      - ./docs:/src/docs:z
-      - ./cnxdb:/src/cnxdb:z
-      - ./htmlcov:/src/htmlcov:z
+      - .:/src
       - ./.dockerfiles/initdb.d/:/docker-entrypoint-initdb.d/:z
       - pg-data:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./.dockerfiles/initdb.d/:/docker-entrypoint-initdb.d/:z
       - pg-data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       - DB_URL=postgresql://rhaptos@/repository
       - DB_SUPER_URL=postgresql://postgres@/repository

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,25 @@ Or::
     pip install -r requirements/test.txt
     py.test
 
+Testing with Docker and Docker Compose
+--------------------------------------
+
+Requirements:
+* Install `Docker <https://docs.docker.com/install/>`_
+* Install `docker-compose <https://docs.docker.com/compose/install/>`_
+
+To help with installation of packages this project also comes with a
+``Dockerfile`` and ``docker-compose.yml`` file.
+
+To run the tests in the test suite execute the following script:
+
+.. code-block:: bash
+
+   $ ./script/tests.local.sh
+
+This should build and run the tests within your local docker container
+environment.
+
 License
 -------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,12 +52,13 @@ Or::
     pip install -r requirements/test.txt
     py.test
 
-Testing with Docker and Docker Compose
---------------------------------------
+Testing with Docker and Docker Compose (recommended)
+----------------------------------------------------
 
 Requirements:
-* Install `Docker <https://docs.docker.com/install/>`_
-* Install `docker-compose <https://docs.docker.com/compose/install/>`_
+
+- Install `Docker <https://docs.docker.com/install/>`_
+- Install `docker-compose <https://docs.docker.com/compose/install/>`_
 
 To help with installation of packages this project also comes with a
 ``Dockerfile`` and ``docker-compose.yml`` file.
@@ -70,6 +71,17 @@ To run the tests in the test suite execute the following script:
 
 This should build and run the tests within your local docker container
 environment.
+
+The commands being executed are named explicitly so the developer can tell what
+is happening.
+
+.. note::
+   The script uses ``Makefile.docker`` located in the root of the project. This
+   file was created to separate concerns from the main Makefile. The main
+   Makefile creates virtualenvs and manages a ``.state`` directory which are
+   not things to be concerned about when operating within the docker container.
+   To not break any of that functionality it was decided to separate actions
+   needed to be taken within the container.
 
 License
 -------

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,6 +1,6 @@
 certifi==2020.4.5.1
 chardet==3.0.4
-cnx-common==1.3.3
+cnx-common==1.3.4
 idna==2.9
 lxml==4.4.3
 psycopg2==2.8.5

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,9 +1,14 @@
-# This project's dependencies
-cnx-common
-cnx-transforms
-lxml
-psycopg2
-sqlalchemy
-rhaptos.cnxmlutils
-venusian
-zope.deprecation
+certifi==2020.4.5.1
+chardet==3.0.4
+cnx-common==1.3.3
+idna==2.9
+lxml==4.4.3
+psycopg2==2.8.5
+python-slugify==4.0.0
+requests==2.23.0
+rhaptos.cnxmlutils==1.7.3
+sqlalchemy==1.3.16
+text-unidecode==1.3
+urllib3==1.25.9
+venusian==1.2.0
+zope.deprecation==4.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,11 +6,11 @@ pytest-cov
 pytest-mock
 mock==1.0.1;python_version<="2.7"
 tox
+cnx-query-grammar==0.2.2
+cnx-epub==0.21.1
+cnx-transforms==1.2.0
+rhaptos.cnxmlutils==1.7.3
+cnx-recipes==1.50.0
 
--e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
--e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
--e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
--e git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
--e git+https://github.com/openstax/cnx-transforms.git#egg=cnx-transforms
 # FIXME circular dependency here...
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,6 @@ tox
 cnx-query-grammar==0.2.2
 cnx-epub==0.21.1
 cnx-transforms==1.2.0
-rhaptos.cnxmlutils==1.7.3
 cnx-recipes==1.50.0
 
 # FIXME circular dependency here...

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ pytest
 pytest-cov
 pytest-mock
 mock==1.0.1;python_version<="2.7"
-tox
+tox==3.15.0
 cnx-query-grammar==0.2.2
 cnx-epub==0.21.1
 cnx-transforms==1.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,7 @@ pytest
 pytest-cov
 pytest-mock
 mock==1.0.1;python_version<="2.7"
+tox
 
 -e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,7 @@ cnx-query-grammar==0.2.2
 cnx-epub==0.21.1
 cnx-transforms==1.2.0
 cnx-recipes==1.50.0
+tenacity
 
 # FIXME circular dependency here...
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive

--- a/script/db_wait.py
+++ b/script/db_wait.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import logging
+
+from sqlalchemy import create_engine
+from tenacity import after_log, before_log, retry, stop_after_attempt, wait_fixed
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+max_tries = 10
+wait_seconds = 1
+
+engine = create_engine("postgresql://postgres@/postgres")
+
+
+@retry(
+    stop=stop_after_attempt(max_tries),
+    wait=wait_fixed(wait_seconds),
+    before=before_log(logger, logging.INFO),
+    after=after_log(logger, logging.WARN),
+)
+def init():
+    # Try to create session to check if DB is awake
+    try:
+        logger.debug(engine.__dict__)
+        with engine.connect() as connection:
+            result = connection.execute("SELECT 1")
+    except Exception as e:
+        logger.error(e)
+        raise e
+
+
+def main():
+    logger.info("Initializing service")
+    init()
+    logger.info("Service finished initializing")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/tests.local.sh
+++ b/script/tests.local.sh
@@ -10,7 +10,9 @@ make -f Makefile.docker clean
 docker-compose build
 docker-compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
 docker-compose up -d
-docker-compose exec db wait-for-it -t 30 db:5432
+docker-compose logs db
+
+docker-compose exec db wait-for-it -t 30 0.0.0.0:5432
 
 # Instantiate the testing database, database user, and run tests
 # If these steps do not continue then there may be an issue with the container starting up.

--- a/script/tests.local.sh
+++ b/script/tests.local.sh
@@ -7,12 +7,12 @@ echo "Remove python bytecode files"
 make -f Makefile.docker clean
 
 # Build the image and wait for the database server to come up
-docker-compose build
+docker-compose build --no-cache
 docker-compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
 docker-compose up -d
 docker-compose logs db
 
-docker-compose exec db wait-for-it -t 30 0.0.0.0:5432
+docker-compose exec db make -f Makefile.docker db-wait
 
 # Instantiate the testing database, database user, and run tests
 # If these steps do not continue then there may be an issue with the container starting up.

--- a/script/tests.local.sh
+++ b/script/tests.local.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+# Exit in case of error
+set -e
+
+if [ $(uname -s) = "Linux" ]; then
+    echo "Remove __pycache__ files"
+    sudo find . -type d -name __pycache__ -exec rm -r {} \+
+fi
+
+docker-compose build
+docker-compose down -v --remove-orphans # Remove possibly previous broken stacks left hanging after an error
+docker-compose up -d
+docker-compose exec db wait-for-it -t 10 db:5432
+
+docker-compose exec db psql -U postgres -c "DROP DATABASE IF EXISTS testing"
+docker-compose exec db psql -U postgres -c "CREATE USER tester WITH SUPERUSER PASSWORD 'tester';"
+docker-compose exec db createdb -U postgres -O tester testing
+docker-compose exec db make test 

--- a/script/tests.local.sh
+++ b/script/tests.local.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Remove python bytecode files"
-make clean-pyc
+make -f Makefile.docker clean
 
 # Build the image and wait for the database server to come up
 docker-compose build
@@ -19,4 +19,6 @@ docker-compose exec db psql -U postgres -c "DROP DATABASE IF EXISTS testing"
 docker-compose exec db psql -U postgres -c "DROP ROLE IF EXISTS tester"
 docker-compose exec db psql -U postgres -c "CREATE USER tester WITH SUPERUSER PASSWORD 'tester';"
 docker-compose exec db createdb -U postgres -O tester testing
-docker-compose exec db make test
+docker-compose exec db make -f Makefile.docker flake8
+docker-compose exec db make -f Makefile.docker doc8
+docker-compose exec db make -f Makefile.docker test

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ parentdir_prefix =
 
 [tool:pytest]
 norecursedirs = build dist *.egg-info requirements .state .tox
-addopts = -rxs -v --cov-config .coveragerc
+addopts = -rxs -vvv --tb=long --showlocals --cov-config .coveragerc

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [flake8]
-exclude = *.egg,.state,.tox,setup.py,versioneer.py,build/lib/,dist/,cnxdb/migrations,docs/conf.py,cnxdb/archive-sql/schema/*.py
+exclude = *.egg,.state,.tox,setup.py,versioneer.py,build/lib/,dist/,cnxdb/migrations,docs/conf.py,cnxdb/archive-sql/schema/*.py,.venv
 select = E,W,F,N
 ignore = W504
 

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ setup_requires = (
     )
 install_requires = (
     'cnx-common >= 1.2.1',
-    'cnx-transforms',
-    'psycopg2',
-    'sqlalchemy',
-    'requests',
-    'rhaptos.cnxmlutils',
-    'venusian',
+    'cnx-transforms==1.2.0',
+    'psycopg2==2.8.5',
+    'sqlalchemy==1.3.16',
+    'requests==2.23.0',
+    'rhaptos.cnxmlutils==1.7.3',
+    'venusian==1.2.0',
     'zope.deprecation >= 3.5.0',
     )
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     license='LGPL, See also LICENSE.txt',
     description=description,
     long_description=long_description,
-    setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -2,22 +2,20 @@
 envlist = py27,py3,flake8,doc8
 
 [testenv:py27]
-passenv =
-    AS_VENV_IMPORTABLE
 setenv =
     DB_URL = postgresql://tester@/testing
     DB_SUPER_URL = postgresql://postgres@/testing
+    AS_VENV_IMPORTABLE=true
 deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/main.txt
 commands=py.test --cov={envsitepackagesdir}/cnxdb
 
 [testenv:py3]
-passenv =
-    AS_VENV_IMPORTABLE
 setenv =
     DB_URL = postgresql://tester@/testing
     DB_SUPER_URL = postgresql://postgres@/testing
+    AS_VENV_IMPORTABLE=true
 deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/main.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py27,py3
+envlist = py27,py3,flake8,doc8
 
-[testenv]
+[testenv:py27]
 passenv =
     AS_VENV_IMPORTABLE
 setenv =
@@ -11,3 +11,30 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/main.txt
 commands=py.test --cov={envsitepackagesdir}/cnxdb
+
+[testenv:py3]
+passenv =
+    AS_VENV_IMPORTABLE
+setenv =
+    DB_URL = postgresql://tester@/testing
+    DB_SUPER_URL = postgresql://postgres@/testing
+deps=
+    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/main.txt
+commands=py.test --cov={envsitepackagesdir}/cnxdb
+
+[testenv:flake8]
+basepython = python3
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 .
+
+[testenv:doc8]
+basepython = python2
+skip_install = true
+deps =
+    sphinx
+    doc8
+commands = python bin/doc8 README.rst docs/

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,10 @@ envlist = py27,py3
 
 [testenv]
 passenv =
-    DB_*
     AS_VENV_IMPORTABLE
+setenv =
+    DB_URL = postgresql://tester@/testing
+    DB_SUPER_URL = postgresql://postgres@/testing
 deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/main.txt


### PR DESCRIPTION
* Helps with the issue of devs not being able to run the tests locally.
* Fixes a number of issues with dependency conflicts  by pinning dependencies.
* Adds a "one stop shop" script for use when running the tests locally using docker and docker-compose.
* Added documentation on how to run the tests using docker-compose.